### PR TITLE
PLANET-2222 - Minify child theme css

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
 			"@core:config", "@core:install", "@plugin:activate", "@theme:activate",
 			"@download:searchwp", "@install:searchwp",
 			"@core:initial-content", "@core:add-author-capabilities", "@core:add-contributor-capabilities", "@redis:enable",
-			"@core:style", "@core:js", "@core:js-minify", "@site:custom"
+			"@core:style", "@core:style-child", "@core:js", "@core:js-minify", "@site:custom"
 		],
 
 		"site-update": [
@@ -69,7 +69,7 @@
 			"@reset:themes", "@reset:plugins", "@copy:themes", "@copy:assets", "@copy:plugins",
 			"@core:updatedb", "@plugin:activate", "@theme:activate",
 			"@download:searchwp", "@install:searchwp",
-			"@core:add-contributor-capabilities", "@redis:enable", "@core:style", "@core:js", "@core:js-minify", "@site:custom"
+			"@core:add-contributor-capabilities", "@redis:enable", "@core:style", "@core:style-child", "@core:js", "@core:js-minify", "@site:custom"
 		],
 
 		"docker-site-install": [
@@ -77,7 +77,7 @@
 			"@reset:themes", "@copy:themes", "@copy:assets", "@copy:plugins",
 			"@core:config", "@core:install", "@plugin:activate", "@theme:activate",
 			"@download:searchwp", "@install:searchwp",
-			"@core:initial-content", "@core:style", "@core:js", "@core:js-minify", "@site:custom"
+			"@core:initial-content", "@core:style", "@core:style-child", "@core:js", "@core:js-minify", "@site:custom"
 		],
 
 		"theme:install": ["@copy:theme", "@theme:activate"],
@@ -106,6 +106,8 @@
 		"core:add-contributor-capabilities": "wp cap add contributor upload_files",
 
 		"core:style" : "pscss -f=compressed public/wp-content/themes/planet4-master-theme/assets/scss/style.scss > public/wp-content/themes/planet4-master-theme/style.css",
+		"core:style-child" : "cd public/wp-content/themes/; for i in planet4-child-theme*; do cd $i; minifycss style.css > style.min.css; cd ..; done",
+
 		"core:js" : "cat public/wp-content/themes/planet4-master-theme/assets/js/partials/*.js > public/wp-content/themes/planet4-master-theme/assets/js/custom.js",
 		"core:js-minify" : "minifyjs public/wp-content/themes/planet4-master-theme/assets/js/custom.js > public/wp-content/themes/planet4-master-theme/assets/js/main.js",
 


### PR DESCRIPTION
Tested it locally in docker and seems to work fine. It's a script that uses a for loop to minify all present child themes' css code.

I'll open PRs on all current child themes to use `style.min.css`, once this is merged.