### PR TITLE
PLANET-2318 - Move out plugin-blocks frontend code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,13 +111,13 @@
 		"core:style" : "pscss -f=compressed public/wp-content/themes/planet4-master-theme/assets/scss/style.scss > public/wp-content/themes/planet4-master-theme/style.css",
 		"core:style-child" : "cd public/wp-content/themes/; for i in planet4-child-theme*; do cd $i; minifycss style.css > style.min.css; cd ..; done",
 
-		"copy:style-blocks" : "rsync -ar public/wp-content/themes/planet4-master-theme/assets/scss/partials public/wp-content/plugins/planet4-plugin-blocks/assets/scss/partials; rsync -ar public/wp-content/themes/planet4-master-theme/assets/scss/modules public/wp-content/plugins/planet4-plugin-blocks/assets/scss/modules",
-		"core:style-blocks" : "pscss -f=compressed public/wp-content/plugins/planet4-plugin-blocks/assets/scss/style.scss > public/wp-content/themes/planet4-master-theme/blocks.css",
+		"copy:style-blocks" : "rsync -ar public/wp-content/themes/planet4-master-theme/assets/scss/partials public/wp-content/plugins/planet4-plugin-blocks/assets/scss/; rsync -ar public/wp-content/themes/planet4-master-theme/assets/scss/modules public/wp-content/plugins/planet4-plugin-blocks/assets/scss/",
+		"core:style-blocks" : "pscss -f=compressed public/wp-content/plugins/planet4-plugin-blocks/assets/scss/style.scss > public/wp-content/plugins/planet4-plugin-blocks/assets/scss/blocks.css",
 
 		"core:js" : "cat public/wp-content/themes/planet4-master-theme/assets/js/partials/*.js > public/wp-content/themes/planet4-master-theme/assets/js/custom.js",
 		"core:js-minify" : "minifyjs public/wp-content/themes/planet4-master-theme/assets/js/custom.js > public/wp-content/themes/planet4-master-theme/assets/js/main.js",
 		"core:js-blocks" : "cat public/wp-content/plugins/planet4-plugin-blocks/assets/js/partials/*.js > public/wp-content/plugins/planet4-plugin-blocks/assets/js/custom.js",
-		"core:js-blocks-minify" : "minifyjs public/wp-content/plugins/planet4-plugin-blocks/assets/js/custom.js > public/wp-content/themes/planet4-master-theme/assets/js/blocks.js",
+		"core:js-blocks-minify" : "minifyjs public/wp-content/plugins/planet4-plugin-blocks/assets/js/custom.js > public/wp-content/plugins/planet4-plugin-blocks/assets/js/blocks.js",
 
 		"plugin:deactivate": "wp plugin deactivate --all",
 		"plugin:activate": "wp plugin activate --all",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
 			"@core:config", "@core:install", "@plugin:activate", "@theme:activate",
 			"@download:searchwp", "@install:searchwp",
 			"@core:initial-content", "@core:add-author-capabilities", "@core:add-contributor-capabilities", "@redis:enable",
-			"@core:style", "@core:style-child", "@core:js", "@core:js-minify", "@site:custom"
+			"@core:style", "@core:style-child", "@copy:style-blocks", "@core:style-blocks",
+			"@core:js", "@core:js-minify", "@core:js-blocks", "@core:js-blocks-minify", "@site:custom"
 		],
 
 		"site-update": [
@@ -69,7 +70,8 @@
 			"@reset:themes", "@reset:plugins", "@copy:themes", "@copy:assets", "@copy:plugins",
 			"@core:updatedb", "@plugin:activate", "@theme:activate",
 			"@download:searchwp", "@install:searchwp",
-			"@core:add-contributor-capabilities", "@redis:enable", "@core:style", "@core:style-child", "@core:js", "@core:js-minify", "@site:custom"
+			"@core:add-contributor-capabilities", "@redis:enable", "@core:style", "@core:style-child", "@copy:style-blocks", "@core:style-blocks",
+			"@core:js", "@core:js-minify", "@core:js-blocks", "@core:js-blocks-minify", "@site:custom"
 		],
 
 		"docker-site-install": [
@@ -77,7 +79,8 @@
 			"@reset:themes", "@copy:themes", "@copy:assets", "@copy:plugins",
 			"@core:config", "@core:install", "@plugin:activate", "@theme:activate",
 			"@download:searchwp", "@install:searchwp",
-			"@core:initial-content", "@core:style", "@core:style-child", "@core:js", "@core:js-minify", "@site:custom"
+			"@core:initial-content", "@core:style", "@core:style-child", "@copy:style-blocks", "@core:style-blocks",
+			"@core:js", "@core:js-minify", "@core:js-blocks", "@core:js-blocks-minify", "@site:custom"
 		],
 
 		"theme:install": ["@copy:theme", "@theme:activate"],
@@ -108,8 +111,13 @@
 		"core:style" : "pscss -f=compressed public/wp-content/themes/planet4-master-theme/assets/scss/style.scss > public/wp-content/themes/planet4-master-theme/style.css",
 		"core:style-child" : "cd public/wp-content/themes/; for i in planet4-child-theme*; do cd $i; minifycss style.css > style.min.css; cd ..; done",
 
+		"copy:style-blocks" : "rsync -ar public/wp-content/themes/planet4-master-theme/assets/scss/partials public/wp-content/plugins/planet4-plugin-blocks/assets/scss/partials; rsync -ar public/wp-content/themes/planet4-master-theme/assets/scss/modules public/wp-content/plugins/planet4-plugin-blocks/assets/scss/modules",
+		"core:style-blocks" : "pscss -f=compressed public/wp-content/plugins/planet4-plugin-blocks/assets/scss/style.scss > public/wp-content/themes/planet4-master-theme/blocks.css",
+
 		"core:js" : "cat public/wp-content/themes/planet4-master-theme/assets/js/partials/*.js > public/wp-content/themes/planet4-master-theme/assets/js/custom.js",
 		"core:js-minify" : "minifyjs public/wp-content/themes/planet4-master-theme/assets/js/custom.js > public/wp-content/themes/planet4-master-theme/assets/js/main.js",
+		"core:js-blocks" : "cat public/wp-content/plugins/planet4-plugin-blocks/assets/js/partials/*.js > public/wp-content/plugins/planet4-plugin-blocks/assets/js/custom.js",
+		"core:js-blocks-minify" : "minifyjs public/wp-content/plugins/planet4-plugin-blocks/assets/js/custom.js > public/wp-content/themes/planet4-master-theme/assets/js/blocks.js",
 
 		"plugin:deactivate": "wp plugin deactivate --all",
 		"plugin:activate": "wp plugin activate --all",


### PR DESCRIPTION
This makes the necessary changes for these two PRs to work:
greenpeace/planet4-plugin-blocks#301
greenpeace/planet4-master-theme#520

This would need some local testing to make sure we don't break anything.