### PR TITLE
Trigger all sites only after hold->approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,34 +208,7 @@ jobs:
           name: Trigger Planet 4 NRO sites
           command: |
               sites=(
-                "africa" \
-                "argentina" \
-                "belgium" \
-                "brasil" \
-                "canada" \
-                "chile" \
-                "colombia" \
-                "croatia" \
-                "czech-republic" \
-                "defaultcontent" \
-                "denmark" \
-                "dev-search" \
-                "eu-unit" \
-                "flibble" \
-                "finland" \
-                "greece" \
-                "handbook" \
-                "hungary" \
-                "india" \
-                "international" \
-                "italy" \
-                "japan" \
-                "luxembourg" \
-                "mena" \
-                "mexico" \
-                "netherlands" \
-                "new-zealand" \
-                "storytelling" \
+                "koyansync" \
               )
               for i in "${sites[@]}"
               do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,10 +194,6 @@ jobs:
           when: on_fail
           command: notify-job-failure.sh
 
-
-
-
-
   trigger-planet4:
     docker:
       - image: gcr.io/planet-4-151612/circleci-base:latest
@@ -212,7 +208,35 @@ jobs:
           name: Trigger Planet 4 NRO sites
           command: |
               sites=(
-                "koyansync" \
+                "africa" \
+                "argentina" \
+                "belgium" \
+                "brasil" \
+                "canada" \
+                "chile" \
+                "colombia" \
+                "croatia" \
+                "czech-republic" \
+                "defaultcontent" \
+                "denmark" \
+                "dev-search" \
+                "eu-unit" \
+                "flibble" \
+                "finland" \
+                "greece" \
+                "handbook" \
+                "hungary" \
+                "india" \
+                "international" \
+                "italy" \
+                "japan" \
+                "luxembourg" \
+                "mena" \
+                "mexico" \
+                "netherlands" \
+                "new-zealand" \
+                "storytelling" \
+                "sweden" \
               )
               for i in "${sites[@]}"
               do
@@ -322,45 +346,35 @@ workflows:
           - build-branch
         filters:
           branches:
-            only:
-              - develop
-              - trigger-only-with-prespecified-text
+            only: develop
     - hold-promote:
         type: approval
         requires:
           - deploy-develop
         filters:
           branches:
-            only:
-              - develop
-              - trigger-only-with-prespecified-text
+            only: develop
     - hold-trigger-planet4:
         type: approval
         requires:
           - deploy-develop
         filters:
           branches:
-            only:
-              - develop
-              - trigger-only-with-prespecified-text
+            only: develop
     - trigger-planet4:
         context: org-global
         requires:
           - hold-trigger-planet4
         filters:
           branches:
-            only:
-              - develop
-              - trigger-only-with-prespecified-text
+            only: develop
     - notify-promote:
         context: org-global
         requires:
           - deploy-develop
         filters:
           branches:
-            only:
-              - develop
-              - trigger-only-with-prespecified-text
+            only: develop
     - promote:
         context: org-global
         requires:
@@ -368,6 +382,4 @@ workflows:
           - notify-promote
         filters:
           branches:
-            only:
-              - develop
-              - trigger-only-with-prespecified-text
+            only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,10 @@ jobs:
           when: on_fail
           command: notify-job-failure.sh
 
+
+
+
+
   trigger-planet4:
     docker:
       - image: gcr.io/planet-4-151612/circleci-base:latest
@@ -318,28 +322,45 @@ workflows:
           - build-branch
         filters:
           branches:
-            only: develop
+            only:
+              - develop
+              - trigger-only-with-prespecified-text
     - hold-promote:
         type: approval
         requires:
           - deploy-develop
         filters:
           branches:
-            only: develop
-    - trigger-planet4:
-        context: org-global
+            only:
+              - develop
+              - trigger-only-with-prespecified-text
+    - hold-trigger-planet4:
+        type: approval
         requires:
           - deploy-develop
         filters:
           branches:
-            only: develop
+            only:
+              - develop
+              - trigger-only-with-prespecified-text
+    - trigger-planet4:
+        context: org-global
+        requires:
+          - hold-trigger-planet4
+        filters:
+          branches:
+            only:
+              - develop
+              - trigger-only-with-prespecified-text
     - notify-promote:
         context: org-global
         requires:
           - deploy-develop
         filters:
           branches:
-            only: develop
+            only:
+              - develop
+              - trigger-only-with-prespecified-text
     - promote:
         context: org-global
         requires:
@@ -347,4 +368,6 @@ workflows:
           - notify-promote
         filters:
           branches:
-            only: develop
+            only:
+              - develop
+              - trigger-only-with-prespecified-text


### PR DESCRIPTION
Instead of using a predifined text (as was the original idea) I have implemented this with a hold-approve step in the planet4-base-fork workflow
You can see it at work at: https://circleci.com/workflow-run/28510d27-bd10-4adf-9e1c-09dde7429806
![trigger-hold-approve](https://user-images.githubusercontent.com/2528229/50962903-f0ac7600-14d3-11e9-9153-614f76d0277d.png)

Additionally: added sweden site to the list of sites to be triggered.