### PR TITLE
PLANET-3216 fix reindex elasticpress script

### DIFF
--- a/tasks/post-deploy/02-reindex-elasticpress.sh
+++ b/tasks/post-deploy/02-reindex-elasticpress.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 wp config set --add --type=constant EP_HOST http://p4-es-elasticsearch-client.default.svc.cluster.local:9200
-# wp elasticpress activate-feature documents
-# wp elasticpress index --show-bulk-errors
+wp elasticpress deactivate-feature documents || true
+wp elasticpress activate-feature documents || true
+wp elasticpress index --show-bulk-errors || true


### PR DESCRIPTION
Allow execution to continue even if one of the wp elasticpress commands fails, so that building does not stop.