### PR TITLE
Feature/lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
+---
 defaults: &defaults
   docker:
     - image: gcr.io/planet-4-151612/p4-builder:latest
-  working_directory:  /home/circleci/
+  working_directory: /home/circleci/
 
 version: 2
 
@@ -250,7 +251,7 @@ jobs:
   notify-promote:
     docker:
       - image: gcr.io/planet-4-151612/circleci-base:latest
-    working_directory:  /tmp/workspace/app
+    working_directory: /tmp/workspace/app
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -274,7 +275,7 @@ jobs:
   promote:
     docker:
       - image: gcr.io/planet-4-151612/circleci-base:latest
-    working_directory:  /tmp/workspace/app
+    working_directory: /tmp/workspace/app
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -317,68 +318,67 @@ jobs:
           command: TYPE="Promote $(cat /tmp/workspace/var/new_version)" notify-job-failure.sh
 
 
-
 workflows:
   version: 2
   develop:
     jobs:
-    - build-branch:
-        context: org-global
-        filters:
-          branches:
-            ignore: master
-          tags:
-            ignore: /.*/
-    - test-codeception:
-        context: org-global
-        requires:
-          - build-branch
-        filters:
-          branches:
-            only: develop
-    - deploy-develop:
-        context: org-global
-        requires:
-          - build-branch
-        filters:
-          branches:
-            only: develop
-    - hold-promote:
-        type: approval
-        requires:
-          - deploy-develop
-          - test-codeception
-        filters:
-          branches:
-            only: develop
-    - hold-trigger-planet4:
-        type: approval
-        requires:
-          - deploy-develop
-          - test-codeception
-        filters:
-          branches:
-            only: develop
-    - trigger-planet4:
-        context: org-global
-        requires:
-          - hold-trigger-planet4
-        filters:
-          branches:
-            only: develop
-    - notify-promote:
-        context: org-global
-        requires:
-          - deploy-develop
-          - test-codeception
-        filters:
-          branches:
-            only: develop
-    - promote:
-        context: org-global
-        requires:
-          - hold-promote
-          - notify-promote
-        filters:
-          branches:
-            only: develop
+      - build-branch:
+          context: org-global
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/
+      - test-codeception:
+          context: org-global
+          requires:
+            - build-branch
+          filters:
+            branches:
+              only: develop
+      - deploy-develop:
+          context: org-global
+          requires:
+            - build-branch
+          filters:
+            branches:
+              only: develop
+      - hold-promote:
+          type: approval
+          requires:
+            - deploy-develop
+            - test-codeception
+          filters:
+            branches:
+              only: develop
+      - hold-trigger-planet4:
+          type: approval
+          requires:
+            - deploy-develop
+            - test-codeception
+          filters:
+            branches:
+              only: develop
+      - trigger-planet4:
+          context: org-global
+          requires:
+            - hold-trigger-planet4
+          filters:
+            branches:
+              only: develop
+      - notify-promote:
+          context: org-global
+          requires:
+            - deploy-develop
+            - test-codeception
+          filters:
+            branches:
+              only: develop
+      - promote:
+          context: org-global
+          requires:
+            - hold-promote
+            - notify-promote
+          filters:
+            branches:
+              only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,12 @@ defaults: &defaults
 version: 2
 
 jobs:
+  lint:
+    docker:
+      - image: gcr.io/planet-4-151612/circleci-base:latest
+    steps:
+      - checkout
+      - run: make lint
   build-branch:
     <<: *defaults
     environment:
@@ -320,10 +326,13 @@ jobs:
 
 workflows:
   version: 2
-  develop:
+  branch:
     jobs:
+      - lint
       - build-branch:
           context: org-global
+          requires:
+            - lint
           filters:
             branches:
               ignore: master
@@ -335,7 +344,7 @@ workflows:
             - build-branch
           filters:
             branches:
-              only: develop
+              ignore: master
       - deploy-develop:
           context: org-global
           requires:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+# Workaround to make Docker happy on WSL
+docker ps >/dev/null || export DOCKER_HOST=tcp://localhost:2375
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+make -j lint || exit 1
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against --

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+---
+extends: default
+
+rules:
+  line-length: disable

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+
+# ============================================================================
+
+# Check necessary commands exist
+
+CIRCLECI := $(shell command -v circleci 2> /dev/null)
+COMPOSER := $(shell command -v composer 2> /dev/null)
+JQ := $(shell command -v jq 2> /dev/null)
+SHELLCHECK := $(shell command -v shellcheck 2> /dev/null)
+YAMLLINT := $(shell command -v yamllint 2> /dev/null)
+
+# ============================================================================
+
+lint: init
+	@$(MAKE) -kj lint-ci lint-sh lint-yaml lint-json lint-composer
+
+init:
+	@chmod 755 .githooks/*
+	@find .git/hooks -type l -exec rm {} \;
+	@find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
+
+# ============================================================================
+
+lint-sh:
+ifndef SHELLCHECK
+$(error "shellcheck is not installed: https://github.com/koalaman/shellcheck")
+endif
+	@find . -type f -name '*.sh' ! -path './tests/vendor/*' | xargs shellcheck
+
+lint-yaml:
+ifndef YAMLLINT
+$(error "yamllint is not installed: https://github.com/adrienverge/yamllint")
+endif
+	@find . -type f -name '*.yml' ! -path './tests/vendor/*' | xargs yamllint
+
+lint-json:
+ifndef JQ
+$(error "jq is not installed: https://stedolan.github.io/jq/download/")
+endif
+	@find . -type f -name '*.json' ! -path './tests/vendor/*' | xargs jq type | grep -q '"object"'
+
+lint-composer:
+ifndef COMPOSER
+$(error "composer is not installed: https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos")
+endif
+	@find . -type f -name 'composer*.json' ! -path './tests/vendor/*' -exec composer validate {} \;
+
+lint-ci:
+ifndef CIRCLECI
+$(error "circleci is not installed: https://circleci.com/docs/2.0/local-cli/#installation")
+endif
+	@circleci config validate >/dev/null

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -1,3 +1,4 @@
+---
 paths:
     tests: tests
     output: tests/_output

--- a/composer-local.json
+++ b/composer-local.json
@@ -1,4 +1,7 @@
 {
+	"name": "greenpeace/planet4-base-local",
+	"description": "Dummy Greenpeace Planet4 NRO application",
+	"license": "GPL-3.0-or-later",
 	"require": {
 		"greenpeace/planet4-child-theme" : "*"
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
 	"name": "greenpeace/planet4-base",
 	"version": "1.43.0",
-
+	"description": "Core Greenpeace Planet4 application",
+	"license": "GPL-3.0-or-later",
 	"repositories": [
 		{
 			"type": "composer",

--- a/tasks/pre-deploy/01-demo.sh
+++ b/tasks/pre-deploy/01-demo.sh
@@ -1,2 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
 echo "Running a predeploy script"
 cat > foo.txt

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -4,7 +4,7 @@
 # Perform tests in browser using the WPWebDriver or WPBrowser.
 # Use WPDb to set up your initial database fixture.
 # If you need both WPWebDriver and WPBrowser tests - create a separate suite.
-
+---
 actor: AcceptanceTester
 modules:
     enabled:
@@ -22,7 +22,8 @@ modules:
             cleanup: false
             waitlock: 0
             url: '%TEST_SITE_WP_URL%'
-            urlReplacement: true #replace the hardcoded dump URL with the one above
+            #  replace the hardcoded dump URL with the one above
+            urlReplacement: true
             tablePrefix: '%TEST_SITE_TABLE_PREFIX%'
         WPWebDriver:
             url: '%TEST_SITE_WP_URL%'
@@ -37,8 +38,8 @@ modules:
             adminPath: '%TEST_SITE_WP_ADMIN_PATH%'
             clear_cookies: true
         WPCLI:
-          path: /app/source/public
-          throw: true
+            path: /app/source/public
+            throw: true
 extensions:
     enabled:
         - Codeception\Extension\Recorder

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,5 +1,7 @@
 {
-	"name": "greenpeace/planet4-base/tests",
+	"name": "greenpeace/planet4-base-tests",
+	"description": "Tests for the Greenpeace Planet4 NRO application",
+	"license": "GPL-3.0-or-later",
 	"repositories": [
 		{
 			"type": "composer",

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "005eb6842037e06667b2c45aa93aa35d",
+    "content-hash": "fc60c2eddb3f55bbc2c57c0651982eeb",
     "packages": [],
     "packages-dev": [
         {
@@ -2366,6 +2366,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
         },
         {


### PR DESCRIPTION
Adds a linting suite to CI and local development, including pre-commit hooks.

- pre-commit hooks installed with `make init`
- CI linting via `circleci config validate`
- YAML linting via `yamllint`
- JSON linting via `jq`
- Bash linting via `shellcheck`
- Composer linting via `composer validate`
- All recommended fixes applied
- Warns if required executables are not installed

Has no effect on local development unless you run 'make init', which will configure the git pre-commit hook.

Tested: https://circleci.com/gh/greenpeace/planet4-base-fork/1702