### PR TITLE
Add post deploy task that gets gp repos and posts them as wp option

### DIFF
--- a/tasks/post-deploy/03-get-gp-packages.sh
+++ b/tasks/post-deploy/03-get-gp-packages.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+master_json=$(jq '[.packages | .[] | select(.name | startswith( "greenpeace")) | [.name , .version , .source]]' composer.lock)
+echo "$master_json"
+
+wp option update greenpeace_packages --format=json "$master_json"


### PR DESCRIPTION
[Jira Issue PLANET-3498](https://jira.greenpeace.org/browse/PLANET-3498)
Scan the composer-lock file to get the data needed in order to produce the dev report of which version from each repo we used. Then post it in the wp options to be used in the master theme if it exists.

Tested at koyansync site https://circleci.com/gh/greenpeace/planet4-koyansync/842