### PR TITLE
Remove unused dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
 		"greenpeace/planet4-plugin-blocks" : "1.42",
 		"greenpeace/planet4-plugin-engagingnetworks": "1.8",
 		"greenpeace/planet4-plugin-medialibrary" : "1.7",
-		"matthiasmullie/minify": "^1.3",
 		"wikimedia/composer-merge-plugin": "1.4.1",
 		"wpackagist-plugin/akismet": "4.*",
 		"wpackagist-plugin/classic-editor":"1.*",


### PR DESCRIPTION
We no longer use `minify` command on composer.