### PR TITLE
Chore/tidy post deploy

### DIFF
--- a/tasks/post-deploy/01-flush_permalinks.sh
+++ b/tasks/post-deploy/01-flush_permalinks.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-# wp rewrite flush

--- a/tasks/post-deploy/02-connect2es.sh
+++ b/tasks/post-deploy/02-connect2es.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-ELASTICSEARCH_HOST=http://p4-es-elasticsearch-client.default.svc.cluster.local:9200/
-wp option update ep_host $ELASTICSEARCH_HOST


### PR DESCRIPTION
Remove unnecessary scripts from the post-deploy folder.

- `tasks/post-deploy/01-flush_permalinks.sh` - this has been commented out forever
- `tasks/post-deploy/02-connect2es.sh` - all current sites have the hostname set correctly, and the defaultcontent also has it set correctly.
