### PR TITLE
Update acceptance suite configuration for recorder extension

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -45,5 +45,5 @@ extensions:
         - Codeception\Extension\Recorder
     config:
         Codeception\Extension\Recorder:
-            delete_successful: false
+            delete_successful: true
             module: WPWebDriver


### PR DESCRIPTION
Set codeception recorder extension to not keep artifacts for successful tests.
As the tests suite is growing it could save us some seconds in ci jobs.