### PR TITLE
PLANET-3899 fix createEnBlock test

### DIFF
--- a/tests/_support/Page/ENBlock.php
+++ b/tests/_support/Page/ENBlock.php
@@ -2,29 +2,26 @@
 
 namespace Page;
 
+/**
+ * Declare UI map for this page here. CSS or XPath allowed.
+ * public static $usernameField = '#username';
+ * public static $formSubmitButton = "#mainForm input[type=submit]";
+ */
 class ENBlock {
-	/**
-	 * Declare UI map for this page here. CSS or XPath allowed.
-	 * public static $usernameField = '#username';
-	 * public static $formSubmitButton = "#mainForm input[type=submit]";
-	 */
-
-	// include url of current page
-	public static $URL = '/wp-admin/post-new.php?post_type=p4en_form';
-
-	public static $shortcodeName = 'shortcake_enblock';
-	public static $addFieldButton = '.add-en-field';
-
-	public static $pageElementButton = '[data-shortcode="shortcake_enblock"]';
-	public static $enPageSelect = 'en_page_id';
-	public static $formStyleRadio = 'input[name=en_form_style]';
-	public static $formStyleInputName = 'en_form_style';
-	public static $goalSelect = 'enform_goal';
-	public static $titleField = 'title';
-	public static $descriptionField = 'description';
-	public static $contentTitleField = 'content_title';
+	// Include url of current page.
+	public static $URL                     = '/wp-admin/post-new.php?post_type=p4en_form';
+	public static $shortcodeName           = 'shortcake_enblock';
+	public static $addFieldButton          = '.add-en-field';
+	public static $pageElementButton       = '[data-shortcode="shortcake_enblock"]';
+	public static $enPageSelect            = 'en_page_id';
+	public static $formStyleRadio          = 'input[name=en_form_style]';
+	public static $formStyleInputName      = 'en_form_style';
+	public static $goalSelect              = 'enform_goal';
+	public static $titleField              = 'title';
+	public static $descriptionField        = 'description';
+	public static $contentTitleField       = 'content_title';
 	public static $contentDescriptionField = 'content_description';
-	public static $buttonTextField = 'button_text';
-	public static $enFormSelect = 'en_form_id';
-
+	public static $buttonTextField         = 'button_text';
+	public static $enFormSelect            = 'en_form_id';
+	public static $enTitleSizeSelect       = 'content_title_size';
 }

--- a/tests/_support/plugins/engagingnetworks/ensapi_sample_question_3877_response.json
+++ b/tests/_support/plugins/engagingnetworks/ensapi_sample_question_3877_response.json
@@ -14,7 +14,7 @@
 						"imageUrl": "",
 						"selected": false,
 						"value": "Y",
-						"label": "Yes, I would like to receive updates via email&amp;nbsp;&lt;a href=\"https://www.google.com\" target=\"_blank\"&gt;https://www.google.com&lt;/a&gt;\n"
+						"label": "Yes, I would like to receive updates via email. This is a link example <a href=\"https://www.google.com\" target=\"_blank\">https://www.google.com</a>"
 					}
 				]
 			}


### PR DESCRIPTION
Fix `createAnEnformPage` [test which broke](https://circleci.com/gh/greenpeace/planet4-base-fork/2782) when a new required field was introduced in the ENBlock in this [PR](https://github.com/greenpeace/planet4-plugin-engagingnetworks/pull/166)

![image](https://user-images.githubusercontent.com/14092452/62613770-cb210700-b912-11e9-8c5a-da3163881ae3.png)
