### PR TITLE
Remove obsolete minifycss script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,25 +67,24 @@
 			"@reset:themes", "@reset:plugins", "@copy:themes", "@copy:plugins",
 			"@core:config", "@core:install", "@plugin:activate", "@theme:activate",
 			"@core:add-author-capabilities", "@core:add-contributor-capabilities", "@redis:enable",
-			"@core:style-child", "@site:custom"
+			"@site:custom"
 		],
 
 		"site-update": [
 			"@download:wordpress", "@copy:health-check",
 			"@reset:themes", "@reset:plugins", "@copy:themes", "@copy:plugins",
 			"@core:updatedb", "@plugin:activate", "@theme:activate",
-			"@core:add-contributor-capabilities", "@redis:enable", "@core:style-child", "@site:custom"
+			"@core:add-contributor-capabilities", "@redis:enable", "@site:custom"
 		],
 
 		"docker-site-install": [
 			"@download:wordpress", "@copy:health-check",
 			"@reset:themes", "@copy:themes", "@copy:plugins",
 			"@core:config", "@core:install", "@plugin:activate", "@theme:activate",
-			"@core:style-child", "@site:custom"
+			"@site:custom"
 		],
 
 		"site:global": [
-			"@core:style-child",
 			"@site:custom"
 		],
 
@@ -107,8 +106,6 @@
 		"core:updatedb": "wp core update-db",
 		"core:add-author-capabilities": "wp cap add author edit_others_posts; wp cap add author delete_others_posts; wp cap add author delete_private_posts;wp cap add author edit_private_posts;wp cap add author read_private_posts;",
 		"core:add-contributor-capabilities": "wp cap add contributor upload_files",
-
-		"core:style-child" : "cd public/wp-content/themes/; for i in planet4-child-theme*; do cd $i; minifycss style.css > style.min.css; cd ..; done",
 
 		"plugin:deactivate": "wp plugin deactivate --all",
 		"plugin:activate": "wp plugin activate --all",


### PR DESCRIPTION
I noticed this failing on CI pipelines. We removed `minifycss` at 8f9cffe7af4a9343edb5c931e8e39a1a60aad285 but we never removed the script.