### PR TITLE
Hide page titles on existing Campaigns

### DIFF
--- a/tasks/post-deploy/05-cpp-hide-title.sh
+++ b/tasks/post-deploy/05-cpp-hide-title.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for i in $(wp post list --post_type=campaign --format=ids)
+do
+    wp post meta set "$i" p4_hide_page_title_checkbox on
+done


### PR DESCRIPTION
This is need for greenpeace/planet4-master-theme#938 in order to avoid affecting existing Campaign pages.