### PR TITLE
PLANET-4358 Update gutenberg conversion script to skip wpml loading

### DIFF
--- a/tasks/post-deploy/04-run-shortcodes-to-gutenberg-conversion.sh
+++ b/tasks/post-deploy/04-run-shortcodes-to-gutenberg-conversion.sh
@@ -15,6 +15,6 @@ done
 
 # Run wp cli command to convert shortcake shortcodes to gutenberg blocks.
 wp cache flush
-wp p4-gblocks convert_to_gutenberg
+wp p4-gblocks convert_to_gutenberg --skip-plugins=sitepress-multilingual-cms,wpml-translation-management,wpml-string-translation,wpml-media-translation
 wp plugin deactivate planet4-plugin-blocks
 wp cache flush


### PR DESCRIPTION
Update gutenberg conversion script to skip wpml related plugins during the conversion.

It seems that in certain cases the wp_update_post that runs after the conversion of the post triggers an infinite loop of save-update post hooks.

https://developer.wordpress.org/reference/hooks/save_post/#avoiding-infinite-loops