### PR TITLE
Add sentry.io plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
 		"wpackagist-plugin/wordfence": "7.*",
 		"wpackagist-plugin/wordpress-importer": "0.*",
 		"wpackagist-plugin/wp-redis": "0.7.*",
+		"wpackagist-plugin/wp-sentry-integration":"3.*",
 		"wpackagist-plugin/wp-stateless": "2.*"
 	},
 


### PR DESCRIPTION
https://wordpress.org/plugins/wp-sentry-integration/

About: https://sentry.io/welcome/

We have a Sentry instance installed on the p4 dev cluster with Google SSO enabled - https://sentry.greenpeace.org

Installed and tested working on https://k8s.p4.greenpeace.org/flibble/

Example error data: https://sentry.greenpeace.org/greenpeace/planet4/issues/1/?query=is%3Aunresolved

No further configuration required, I've already updated helm chart, containers, builder image and CI variable, all that's needed is to add this plugin and we'll start seeing detailed error reporting data in the dashboard.

We can enrich this data with [release tracking](https://docs.sentry.io/workflow/releases/) etc in due course, if we find value in this service.
