### PR TITLE
PLANET-5062 Fix TAB test and re-enable it

### DIFF
--- a/tests/acceptance/TakeActionBoxoutCept.php
+++ b/tests/acceptance/TakeActionBoxoutCept.php
@@ -1,0 +1,24 @@
+<?php
+use \Codeception\Util\Locator;
+
+$I = new AcceptanceTester($scenario);
+
+$I->wantTo('create and check take action boxout block');
+
+$slug = $I->generateRandomSlug();
+
+$I->havePageInDatabase([
+  'post_name'    => $slug,
+  'post_status'  => 'publish',
+  'post_content' => $I->generateGutenberg('wp:planet4-blocks/take-action-boxout', [
+    'take_action_page' => 28
+  ])."Take action boxout block page"
+]);
+
+// Navigate to the newly created page
+$I->amOnPage('/' . $slug);
+
+// Check the Take Action Boxout block
+$I->see('#Climate', '.cover-card .cover-card-tag');
+$I->see('Vestibulum leo libero', '.cover-card h2.cover-card-heading');
+$I->see('Get Involved', '.cover-card a.btn-action');


### PR DESCRIPTION
- The TAB block is added on page [differently](https://github.com/greenpeace/planet4-master-theme/blob/master/single.php#L24). (Strip the Take Action Boxout block from the post content and add outside the normal block container) , because of this the post content will be empty and test failed.
- To fix this issue, I append a extra string in post content.

After adding a extra string to the post content, the test passes.
![image](https://user-images.githubusercontent.com/5357471/83272064-5643f400-a1e8-11ea-8c28-a476aedda323.png)
