### PR TITLE
PLANET-5077: Measure JS code test coverage

### DIFF
--- a/tasks/other/run-js-tests.sh
+++ b/tasks/other/run-js-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+[ -x "$(command -v npm)" ] || { >&2 echo "npm is required but not installed, exiting."; exit 1; }
+
+pushd /app/source/public/wp-content/plugins/planet4-plugin-gutenberg-blocks || exit
+npm test
+popd || exit


### PR DESCRIPTION
Adding a simple task to run `npm test` in the blocks plugin folder.