### PR TITLE
PLANET-5167: PoC for BDD tests

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -6,7 +6,6 @@ class AcceptanceTester extends \Codeception\Actor
 {
 	use _generated\AcceptanceTesterActions;
 
-
 	/**
 	 * A simple helper to fill in a form without repetitively calling `$I->fillField()`
 	 *
@@ -23,6 +22,8 @@ class AcceptanceTester extends \Codeception\Actor
 	/**
 	 * Login to WordPress as the admin user saving the session as snapshot to make
 	 * subsequent admin logins reuse the session to save time.
+	 *
+	 * @Given I am logged in as administrator
 	 */
 	public function loginAsAdminCached()
 	{
@@ -93,5 +94,4 @@ class AcceptanceTester extends \Codeception\Actor
 		$I = $this;
 		$I->dontHaveCommentInDatabase(['comment_author_email' => $email]);
 	}
-
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -2,6 +2,8 @@
 
 namespace Helper;
 
+use Codeception\Module\WPWebDriver;
+
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
@@ -59,5 +61,16 @@ class Acceptance extends \Codeception\Module
 		$result .= json_encode($data);
 		$result .= ' /-->';
 		return $result;
+	}
+
+	/**
+	 * @param string $selector
+	 * @return bool
+	 */
+	public function checkIfElementExists(string $selector): bool
+	{
+		$wd = $this->getModule('WPWebDriver');
+		return $wd instanceof WPWebDriver 
+			&& !empty($wd->_findElements($selector));
 	}
 }

--- a/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
+++ b/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
@@ -1,0 +1,192 @@
+<?php
+namespace Page\Acceptance\Admin;
+
+class GutenbergEditor
+{
+    // @todo: migrate to specific class as (typed?) constants ?
+    // @todo: and add command to list all known selectors ?
+    public static $mainBlockSelectorButton = '.components-button.block-editor-inserter__toggle';
+    public static $paragraphSelectorButton = '.components-button.editor-block-list-item-paragraph';
+    public static $blockSelectorSection = '//button[contains(@class, "components-button")][text()="%s"]';
+    public static $blockSelectorButton = '//ul[contains(@class, "block-editor-block-types-list")]//button/span[text()="%s"]';
+
+    public static $titleField = '#post-title-1';
+
+    public static $firstEditableParagraph = '.block-editor-block-list__layout [aria-label="Add block"]';
+    public static $editableParagraph = '.block-editor-rich-text__editable';
+
+    public static $prePublishButton = '.editor-post-publish-panel__toggle';
+    public static $publishButton = '.editor-post-publish-button';
+
+    public static $validationMessage = '.components-snackbar__content';
+
+    /**
+     * @var \AcceptanceTester;
+     */
+    protected $tester;
+
+    public function __construct(\AcceptanceTester $I)
+    {
+        $this->tester = $I;
+    }
+
+    /**
+     * @Given I open dashboard page
+     */
+    public function openDashboardPage(): void
+    {
+        $I = $this->tester;
+        $I->amOnPage(Navigation::pageLink('Dashboard'));
+    }
+
+    /**
+     * @Given I am on a new post page
+     */
+    public function newPostPage(): void
+    {
+        $I = $this->tester;
+        $I->amOnPage(Navigation::pageLink('Posts > Add New'));
+    }
+
+    /**
+     * @When I add a title :arg1
+     */
+    public function addTitle(string $title): void
+    {
+        $I = $this->tester;
+        $I->fillField(self::$titleField, $title);
+    }
+
+    /**
+     * @When I add a paragraph :arg1
+     */
+    public function addParagraph(?string $text): void
+    {
+        $I = $this->tester;
+
+        // New post starts with an empty paragraph block,
+        // if it is there, we use it
+        $firstParagraphExists = $I->checkIfElementExists(self::$firstEditableParagraph);
+
+        if ($firstParagraphExists) {
+            $I->click(self::$firstEditableParagraph);
+            $I->waitForElement(self::$editableParagraph, 1);
+        } else {
+            $this->addBlock('Common Blocks > Paragraph');
+            $I->waitForElement(self::$editableParagraph, 1);
+        }
+
+        if (null !== $text) {
+            $I->pressKey(self::$editableParagraph, $text);
+        }
+    }
+
+    /**
+     * @When /I publish the (post|page)/
+     */
+    public function publishPost(): void
+    {
+        $I = $this->tester;
+        $I->click(self::$prePublishButton);
+        $I->waitForElement(self::$publishButton, 1);
+        $I->click(self::$publishButton);
+
+        // @todo: memorize new post id
+    }
+
+    /**
+     * @todo: paste does not currently work
+     * @see self::pasteText()
+     * 
+     * @When I paste a video link :link
+     */
+    public function pasteYoutubeLink(string $link): void
+    {
+        $I = $this->tester;
+
+        $this->addBlock('Embeds > YouTube');
+        $I->pressKey('.has-selected-ui[aria-label="Block: YouTube"] input[type="url"]', $link);
+        $I->click('.has-selected-ui[aria-label="Block: YouTube"] button[type="submit"]');
+    }
+
+    /**
+     * @When I paste :text
+     */
+    public function pasteText(string $text): void
+    {
+        // @todo: paste does not currently work, 
+        // @todo: try ctrl+c or find out why chrome arg doesn't work
+        //$I = $this->tester;
+        //$I->executeJS('navigator.clipboard.writeText(arguments[0])', [$text]);
+        //$this->addParagraph($text);
+        //$I->pressKey('.block-editor-rich-text__editable', ['ctrl', 'v']);
+        throw new \Exception(__METHOD__ . ': not implemented.');
+    }
+
+    /**
+     * Blockpath should be 'Category name > Block name'
+     * @example Embeds > YouTube
+     * @example Layout Elements > Buttons
+     * 
+     * @When I add a block :blockpath
+     */
+    public function addBlock(string $blockpath): void
+    {
+        $I = $this->tester;
+        
+        $path = explode(' > ', $blockpath);
+        $sectionSelector = sprintf(self::$blockSelectorSection, $path[0]);
+        $blockSelector = sprintf(self::$blockSelectorButton, $path[1]);
+
+        $this->openBlockSelector();
+        $I->click($sectionSelector);
+        $I->waitForElement($blockSelector, 1);
+        $I->click($blockSelector);
+    }
+
+    /**
+     * @When I open block selector
+     */
+    public function openBlockSelector(): void
+    {
+        $I = $this->tester;
+        $I->click(self::$mainBlockSelectorButton);
+    }
+
+    /**
+     * @Then a message :message is displayed
+     * @Then I see a message :message
+     */
+    public function messageIsDisplayed(?string $message): void
+    {
+        // @todo: check message content
+        $I = $this->tester;
+        $I->waitForElement(self::$validationMessage, 3);
+    }
+
+    /**
+     * @Then the post is visible on the website
+     */
+    public function postIsVisibleOnWebsite(): void
+    {
+        // @todo: memorize post id to visit
+    }
+
+    /**
+     * @Then I see the video in the editor
+     */
+    public function videoIsEmbedded(): void
+    {
+        // @todo: get reference to video inserted
+        $I = $this->tester;
+        $I->waitForElement('figure.is-type-video iframe');
+    }
+
+    /**
+     * @Then I see the video in the post
+     */
+    public function videoVisibleOnWebsite(): void
+    {
+        // @todo: memorize post id to visit
+    }
+}

--- a/tests/_support/Page/Acceptance/Admin/Navigation.php
+++ b/tests/_support/Page/Acceptance/Admin/Navigation.php
@@ -1,0 +1,47 @@
+<?php
+namespace Page\Acceptance\Admin;
+
+class Navigation
+{
+    /**
+     * @var \AcceptanceTester;
+     */
+    private $tester;
+
+    // @todo: migrate keys to (typed?) constants
+    public static $linkMap = [
+        'Dashboard' => '/wp-admin/index.php',
+        'Posts' => '/wp-admin/edit.php',
+        'Posts > All Posts' => '/wp-admin/edit.php',
+        'Posts > Add New' => '/wp-admin/post-new.php',
+        'Posts > Categories' => '/wp-admin/edit-tags.php?taxonomy=category',
+        'Posts > Tags' => '/wp-admin/edit-tags.php?taxonomy=post_tag',
+        'Posts > Post Types' => '/wp-admin/edit-tags.php?taxonomy=p4-page-type',
+        'Posts > Posts Report' => '/wp-admin/edit.php?taxonomy=posts-report',
+    ];
+
+    public function __construct(\AcceptanceTester $I)
+    {
+        $this->tester = $I;
+    }
+
+    /**
+     * @When I am on admin page :location
+     */
+    public function navigateTo(string $location): void
+    {
+        $I = $this->tester;
+        $I->amOnPage(self::$linkMap[$location]);
+    }
+
+    /**
+     * Return admin page relative URL based on a string 'Group name > Page name'
+     */
+    public static function pageLink(string $pageName): ?string
+    {
+        if (!isset(self::$linkMap[$pageName])) {
+            throw new \Exception('No page named ' . $pageName);
+        }
+        return self::$linkMap[$pageName];
+    }
+}

--- a/tests/_support/Step/Acceptance/Admin/Editor.php
+++ b/tests/_support/Step/Acceptance/Admin/Editor.php
@@ -1,0 +1,12 @@
+<?php
+namespace Step\Acceptance\Admin;
+
+use \Page\Acceptance\Admin\Editor as Selector;
+
+class Editor extends \AcceptanceTester
+{
+    public function __construct()
+    {
+        
+    }
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -37,6 +37,9 @@ modules:
             adminPassword: '%TEST_SITE_ADMIN_PASSWORD%'
             adminPath: '%TEST_SITE_WP_ADMIN_PATH%'
             clear_cookies: true
+            capabilities:
+                chromeOptions:
+                    args: ["--unsafely-treat-insecure-origin-as-secure='%TEST_SITE_WP_URL%'"]
         WPCLI:
             path: /app/source/public
             throw: true
@@ -47,3 +50,10 @@ extensions:
         Codeception\Extension\Recorder:
             delete_successful: true
             module: WPWebDriver
+gherkin:
+    contexts:
+        default:
+            - AcceptanceTester
+            - Page\Acceptance\Admin\GutenbergEditor
+            - Page\Acceptance\Admin\Navigation
+

--- a/tests/acceptance/editor.feature
+++ b/tests/acceptance/editor.feature
@@ -1,0 +1,24 @@
+Feature: editor basics
+  In order to publish content
+  As a logged in admin
+  I need to be able to use the editor
+
+Background:
+  Given I am logged in as administrator
+  And I open dashboard page
+
+  Scenario: Create a new post
+    Given I am on a new post page
+    When I add a title "Test title"
+    And I add a paragraph "Test paragraph"
+    And I publish the post
+    Then a message "Post published." is displayed
+    And the post is visible on the website
+
+  Scenario: Add a youtube video in a post
+    Given I am on a new post page
+    When I add a title "Test video"
+    And I paste a video link "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    And I publish the post
+    Then I see the video in the editor
+    And I see the video in the post


### PR DESCRIPTION
Refs:
- https://jira.greenpeace.org/browse/PLANET-5167
- https://jira.greenpeace.org/browse/PLANET-5168
- https://jira.greenpeace.org/browse/PLANET-5169

PoC of tests written in [Gherkin](https://codeception.com/docs/07-BDD#Gherkin) as a way to facilitate communication and implementation of functional tests.  
After trying to use [Selenium IDE](https://www.selenium.dev/selenium-ide/) in Gutenberg editor, I realized that recording a scenario and replaying it is not a straightforward task; it requires multiple tries to find the right selectors, adding intermediate steps to wait for elements, and finding proper assertions. Although it is a great tool to automate repetitive tasks, it feels like a very technical thing to do in the context of Gutenberg, which is why I've pushed more the topic of textual tests that can be written by non-developers and carefully implemented by developers to be reusable.

## Features

This PR allows to write tests in a `feature` format, a textual format _readable and writable by non-developers_:
```gherkin
  Scenario: Create a new post
    Given I am on a new post page
    When I add a title "Test title"
    And I add a paragraph "Test paragraph"
    And I publish the post
    Then a message "Post published." is displayed
    And the post is visible on the website
```
In this feature, codeception will directly interact with the editor, as a user would do.  
The functionality already exists in Codeception, using it is a matter of implementing sentences into reusable bits of code.  

To match a sentence with a method, annotations are used, `@Given`, `@When` and `@Then`:
```php
	/**
	 * Login to WordPress as the admin user saving the session as snapshot to make
	 * subsequent admin logins reuse the session to save time.
	 *
	 * @Given I am logged in as administrator
	 */
	public function loginAsAdminCached()
```
In this example, I just used an existing method, and made it run againt the sentence `Given I am logged in as administrator`.  
Sentences can become regular expression, to capture parameters or match variations of a sentence:
```php
/**
 * @When /I publish the (post|page)/
 * will match `When I publish the post` and `When I publish the page`
 * @Then I see a message :message
 * will match `Then I see a message "any message"`, and propagate "any message" as first parameter for the method
 */
```

### End goal

By implementing reusable sentences and making available a documented list of those, we can try to reach a point where **a tester writes a feature file that is playable as is**, without any technical intervention. It is in that spirit that the [Jira tickets](https://jira.greenpeace.org/browse/PLANET-5167) were written.  
As the [documentation](https://codeception.com/docs/07-BDD#tests-vs-features) says, **not every test should be described as a feature**. Features are slow to run, it is important to group them efficiently and use them to test valuable features of our code.

### What could be done next

- Writing tests by groups of 10, to see how the code evolves and have time to refactor and define reusable vocabulary with testers
- Get a better sense of the difference between PageObject and StepObject (still confused :|)
- Extract selectors and page names to constant classes, make them available for all tests
  I like [PHP-enum](https://github.com/myclabs/php-enum) because it allows to type hint constants, but we can also do without it
- Make a better use of [WPBrowser](https://wpbrowser.wptestkit.dev/modules/wpbrowser#amonpagespage) functionalities
- Solve the copy/paste problem 😭 

## Tests

Run in your `make php-shell`
```console
$ tests/vendor/bin/codecept run -vv acceptance editor.feature
```
You will see all the steps and intermediate actions executed.

To get a list of all available steps:
```console
$ tests/vendor/bin/codecept gherkin:steps acceptance
Steps from default context:
+------------------------------------+---------------------------------------------------------------+
| Step                               | Implementation                                                |
+------------------------------------+---------------------------------------------------------------+
| I am logged in as administrator    | AcceptanceTester::loginAsAdminCached                          |
| I open dashboard page              | Page\Acceptance\Admin\GutenbergEditor::openDashboardPage      |
| I am on a new post page            | Page\Acceptance\Admin\GutenbergEditor::newPostPage            |
| I add a title :arg1                | Page\Acceptance\Admin\GutenbergEditor::addTitle               |
| I add a paragraph :arg1            | Page\Acceptance\Admin\GutenbergEditor::addParagraph           |
| /I publish the (post|page)/        | Page\Acceptance\Admin\GutenbergEditor::publishPost            |
| I paste a video link :link         | Page\Acceptance\Admin\GutenbergEditor::pasteYoutubeLink       |
| I paste :text                      | Page\Acceptance\Admin\GutenbergEditor::pasteText              |
| I add a block :blockpath           | Page\Acceptance\Admin\GutenbergEditor::addBlock               |
| I open block selector              | Page\Acceptance\Admin\GutenbergEditor::openBlockSelector      |
| a message :message is displayed    | Page\Acceptance\Admin\GutenbergEditor::messageIsDisplayed     |
| I see a message :message           | Page\Acceptance\Admin\GutenbergEditor::messageIsDisplayed     |
| the post is visible on the website | Page\Acceptance\Admin\GutenbergEditor::postIsVisibleOnWebsite |
| I see the video in the editor      | Page\Acceptance\Admin\GutenbergEditor::videoIsEmbedded        |
| I see the video in the post        | Page\Acceptance\Admin\GutenbergEditor::videoVisibleOnWebsite  |
| I am on admin page :location       | Page\Acceptance\Admin\Navigation::navigateTo                  |
+------------------------------------+---------------------------------------------------------------+
```
To check if a step is not yet implemented (not matched by any existing annotation):
```console
$ tests/vendor/bin/codecept dry-run acceptance editor.feature
```

## Resources

- [Codeception - Behavior Driven Development](https://codeception.com/docs/07-BDD)
- [Behat - Defining reusable actions](https://docs.behat.org/en/latest/user_guide/context/definitions.html#step-argument-transformations)
- [Codeception - Webdriver](https://codeception.com/docs/modules/WebDriver.html)
- [Chrome - Unblocking Clipboard Access](https://developers.google.com/web/updates/2018/03/clipboardapi)
- [Chrome - Deprecating Powerful Features on Insecure Origins](https://www.chromium.org/Home/chromium-security/deprecating-powerful-features-on-insecure-origins)
- [XPath cheatsheet](https://devhints.io/xpath)