### PR TITLE
PLANET-5099 Use command instead of eval

### DIFF
--- a/tasks/post-deploy/01-run-p4-activator.sh
+++ b/tasks/post-deploy/01-run-p4-activator.sh
@@ -5,7 +5,7 @@
 # It is meant for running one-off actions like adding custom roles and capabilities.
 if ( wp theme is-active planet4-master-theme ) || ( wp theme status | grep -q 'P planet4-master-theme' )  then
   echo "Run P4_Activator"
-  wp eval '(new P4_Activator())->run();'
+  wp p4-run-activator
 else
   echo "Skip running P4_Activator, neither planet4-master-theme nor one of its child themes is activated."
 fi


### PR DESCRIPTION
Using eval in wp cli makes it harder to provide BC if we change to psr-4, so use a CLI command instead. Can only be merged after the CLI command is merged: https://github.com/greenpeace/planet4-master-theme/pull/1125