### PR TITLE
PLANET-5167: Introduction of features descriptions as tests

### DIFF
--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -30,5 +30,7 @@ extensions:
         - Codeception\Command\GenerateWPAjax
         - Codeception\Command\GenerateWPCanonical
         - Codeception\Command\GenerateWPXMLRPC
+        - Command\Selectors
+        - Command\Steps
 params:
     - .env.codeception

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -2,6 +2,9 @@
 
 use tad\WPBrowser\Generators\Date;
 
+/**
+ * AcceptanceTester: helpers for the AcceptanceTester actor
+ */
 class AcceptanceTester extends \Codeception\Actor
 {
 	use _generated\AcceptanceTesterActions;
@@ -23,6 +26,8 @@ class AcceptanceTester extends \Codeception\Actor
 	/**
 	 * Login to WordPress as the admin user saving the session as snapshot to make
 	 * subsequent admin logins reuse the session to save time.
+	 *
+	 * @Given I am logged in as administrator
 	 */
 	public function loginAsAdminCached()
 	{
@@ -93,5 +98,4 @@ class AcceptanceTester extends \Codeception\Actor
 		$I = $this;
 		$I->dontHaveCommentInDatabase(['comment_author_email' => $email]);
 	}
-
 }

--- a/tests/_support/Command/Selectors.php
+++ b/tests/_support/Command/Selectors.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Command;
+
+use \Symfony\Component\Console\Command\Command;
+use \Codeception\CustomCommandInterface;
+use \Selector\Admin\GutenbergEditor;
+use \Selector\Admin\GutenbergEditor\BlockSelector;
+use Selector\Admin\GutenbergEditor\Sidebar;
+use \Symfony\Component\Console\Input\InputInterface;
+use \Symfony\Component\Console\Output\OutputInterface;
+use \Symfony\Component\Console\Helper\Table;
+use \Symfony\Component\Console\Helper\TableCell;
+use \Symfony\Component\Console\Helper\TableSeparator;
+
+/**
+ * Prints all css/xpath selectors available
+ */
+class Selectors extends Command implements CustomCommandInterface
+{
+    /**
+     * Selectors classes to list
+     *
+     * @var string[]
+     */
+    private $selectorClasses = [
+        GutenbergEditor::class,
+        BlockSelector::class,
+        Sidebar::class,
+    ];
+
+    /**
+     * Returns the name of the command
+     *
+     * @return string
+     */
+    public static function getCommandName(): string
+    {
+        return "p4:selectors";
+    }
+
+    /**
+     * Configures the current command.
+     */
+    protected function configure(): void
+    {
+        parent::configure();
+    }
+
+    /**
+     * Returns the description for the command.
+     *
+     * @return string The description for the command
+     */
+    public function getDescription(): string
+    {
+        return "Listing P4 selectors";
+    }
+
+    /**
+     * Displays a list of available selectors
+     * Highlights variable parts
+     * 
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $table = new Table($output);
+        $table->setHeaders(['Method', 'Selector']);
+        //$table->setColumnMaxWidth(1, 70);
+
+        while ($class = current($this->selectorClasses)) {
+            $table->addRows([
+                [new TableCell(sprintf('<options=bold>%s</>', $class), ['colspan' => 2])],
+                new TableSeparator()
+            ]);
+            $table->addRows(array_map(
+                function ($key, $val) use ($class) { return [
+                    $this->constToMethod($key, $class), 
+                    str_replace('%s', '<fg=yellow;options=bold>%s</>', $val)
+                ]; } ,
+                $class::keys(),
+                $class::values()
+            ));
+
+            next($this->selectorClasses);
+            if (current($this->selectorClasses)) {
+                $table->addRows([new TableSeparator()]);
+            }
+        }
+        $table->render();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Qualifies php-enum const as methods, check if they have specific parameters declaration
+     * 
+     * @param string $const Constant name
+     * @param string $class Class name
+     *
+     * @return string
+     */
+    private function constToMethod(string $const, string $class): string
+    {
+        try {
+            $rfl = new \ReflectionMethod($class, $const);
+            $params = implode(', ', array_map(
+                function ($param) use ($class) {
+                    $ns = (new \ReflectionClass($class))->getNamespaceName();
+                    return str_replace($ns . '\\', '', $param->getType())
+                        . ' $' . $param->getName();
+                }, 
+                $rfl->getParameters()
+            ));
+
+            return $const . '(<fg=yellow>' . $params . '</>)';
+        } catch (\ReflectionException $e) {
+            return $const . '()';
+        }
+    }
+}

--- a/tests/_support/Command/Steps.php
+++ b/tests/_support/Command/Steps.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Command;
+
+use \Codeception\CustomCommandInterface;
+use \Codeception\Test\Loader\Gherkin;
+use Codeception\Util\Annotation;
+use \Symfony\Component\Console\Command\Command;
+use \Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableSeparator;
+use \Symfony\Component\Console\Input\InputArgument;
+use \Symfony\Component\Console\Input\InputInterface;
+use \Symfony\Component\Console\Input\InputOption;
+use \Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Prints all steps from all Gherkin contexts for a specific suite
+ * Extended `gherkin:steps` to categorize steps and print examples
+ *
+ * ```
+ * codecept p4:steps acceptance
+ * ```
+ *
+ */
+class Steps extends Command implements CustomCommandInterface
+{
+    use \Codeception\Command\Shared\Config;
+    use \Codeception\Command\Shared\Style;
+
+    /**
+     * returns the name of the command
+     *
+     * @return string
+     */
+    public static function getCommandName(): string
+    {
+        return "p4:steps";
+    }
+
+    /**
+     * Configures the current command.
+     */
+    protected function configure(): void
+    {
+        $this->setDefinition(
+            [
+                new InputArgument('suite', InputArgument::REQUIRED, 'suite to scan for feature files'),
+                new InputOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Use custom path for config'),
+                new InputOption('implementation', 'i', InputOption::VALUE_NONE, 'Display implementation'),
+            ]
+        );
+        parent::configure();
+    }
+
+    /**
+     * Returns the description for the command.
+     *
+     * @return string The description for the command
+     */
+    public function getDescription(): string
+    {
+        return 'Listing P4 steps';
+    }
+
+    /**
+     * Displays a list of implemented steps
+     *
+     * @return int
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+
+        $this->addStyles($output);
+        $suite = $input->getArgument('suite');
+        $config = $this->getSuiteConfig($suite);
+        $config['describe_steps'] = true;
+        $implementation = $input->getOption('implementation');
+
+        $loader = new Gherkin($config);
+        $steps = $loader->getSteps();
+
+        $colspan = ['colspan' => $implementation ? 3 : 2];
+        $prevClass = null;
+        foreach ($steps as $name => $context) {
+            $table = new Table($output);
+            $table->setHeaders($implementation
+                ? ['Step', 'Examples', 'Implementation']
+                : ['Step', 'Examples']
+            );
+            $output->writeln("Steps from <bold>$name</bold> context:");
+        
+            foreach ($context as $step => $callable) {
+                if (count($callable) < 2) {
+                    continue;
+                }
+
+                [$class, $method] = $callable;
+                if ($class !== $prevClass) {
+                    $this->addClassheader($table, $class, $colspan, null !== $prevClass);
+                    $prevClass = $class;
+                }
+
+                $methodAnnotation = Annotation::forMethod($class, $method);
+                $examples = $methodAnnotation->fetchAll('example');
+                $method = $class . '::' . $method;
+
+                $implementation
+                    ? $table->addRow([$step, implode("\n", $examples), $method])
+                    : $table->addRow([$step, implode("\n", $examples)]);
+            }
+            $table->render();
+        }
+
+        if (!isset($table)) {
+            $output->writeln("No steps are defined, start creating them by running <bold>gherkin:snippets</bold>");
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function addClassheader(
+        Table $table,
+        string $class,
+        array $attrs,
+        bool $addTopSeparator
+    ): void {
+        if ($addTopSeparator) {
+            $table->addRow([new TableSeparator($attrs)]);
+        }
+
+        $classComments = (new \ReflectionClass($class))->getDocComment();
+        preg_match_all('/ \* (.*)/', $classComments, $matches);
+
+        $table->addRows([
+            [new TableCell(
+                sprintf('<options=bold>%s</>', $matches[1][0] ?? $class),
+                $attrs
+            )],
+            [new TableSeparator($attrs)]
+        ]);
+    }
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -2,6 +2,8 @@
 
 namespace Helper;
 
+use Codeception\Module\WPWebDriver;
+
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
@@ -59,5 +61,16 @@ class Acceptance extends \Codeception\Module
 		$result .= json_encode($data);
 		$result .= ' /-->';
 		return $result;
+	}
+
+	/**
+	 * @param string $selector
+	 * @return bool
+	 */
+	public function checkIfElementExists(string $selector): bool
+	{
+		$wd = $this->getModule('WPWebDriver');
+		return $wd instanceof WPWebDriver
+			&& !empty($wd->_findElements($selector));
 	}
 }

--- a/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
+++ b/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Page\Acceptance\Admin;
+
+use Selector\Admin\GutenbergEditor as EditorSelector;
+use Selector\Admin\GutenbergEditor\BlockName;
+use Selector\Admin\GutenbergEditor\BlockSection;
+use Selector\Admin\GutenbergEditor\BlockSelector;
+
+class GutenbergEditor
+{
+    /**
+     * @var \AcceptanceTester;
+     */
+    protected $tester;
+
+    public function __construct(\AcceptanceTester $I)
+    {
+        $this->tester = $I;
+    }
+
+    public function addBlock(BlockSection $blockSection, BlockName $blockName): void
+    {
+        $I = $this->tester;
+        $blockButton = (string) BlockSelector::BLOCK($blockName);
+
+        $this->openBlockSelector();
+        $I->click((string) BlockSelector::SECTION($blockSection));
+        $I->waitForElement($blockButton, 1);
+        $I->click($blockButton);
+    }
+
+    public function openBlockSelector(): void
+    {
+        $I = $this->tester;
+        $I->click((string) BlockSelector::MAIN_BUTTON());
+    }
+}

--- a/tests/_support/Page/Acceptance/Admin/Navigation.php
+++ b/tests/_support/Page/Acceptance/Admin/Navigation.php
@@ -1,0 +1,38 @@
+<?php
+namespace Page\Acceptance\Admin;
+
+class Navigation
+{
+    /**
+     * @var \AcceptanceTester;
+     */
+    private $tester;
+
+    // @todo: migrate keys to (typed?) constants
+    public static $linkMap = [
+        'Dashboard' => '/wp-admin/index.php',
+        'Posts' => '/wp-admin/edit.php',
+        'Posts > All Posts' => '/wp-admin/edit.php',
+        'Posts > Add New' => '/wp-admin/post-new.php',
+        'Posts > Categories' => '/wp-admin/edit-tags.php?taxonomy=category',
+        'Posts > Tags' => '/wp-admin/edit-tags.php?taxonomy=post_tag',
+        'Posts > Post Types' => '/wp-admin/edit-tags.php?taxonomy=p4-page-type',
+        'Posts > Posts Report' => '/wp-admin/edit.php?taxonomy=posts-report',
+    ];
+
+    public function __construct(\AcceptanceTester $I)
+    {
+        $this->tester = $I;
+    }
+
+    /**
+     * Return admin page relative URL based on a string 'Group name > Page name'
+     */
+    public static function pageLink(string $pageName): ?string
+    {
+        if (!isset(self::$linkMap[$pageName])) {
+            throw new \Exception('No page named ' . $pageName);
+        }
+        return self::$linkMap[$pageName];
+    }
+}

--- a/tests/_support/Selector/Admin/GutenbergEditor.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Selector\Admin;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Selectors in the post content editor
+ * 
+ * @method static GutenbergEditor TITLE_FIELD()
+ * @method static GutenbergEditor EDITABLE_PARAGRAPH()
+ * @method static GutenbergEditor FIRST_EDITABLE_PARAGRAPH()
+ * @method static GutenbergEditor PRE_PUBLISH_BUTTON()
+ * @method static GutenbergEditor PUBLISH_BUTTON()
+ * @method static GutenbergEditor VALIDATION_MESSAGE()
+ * @method static GutenbergEditor SIDEBAR()
+ */
+class GutenbergEditor extends Enum
+{
+    private const TITLE_FIELD = '#post-title-1';
+    private const EDITABLE_PARAGRAPH = '.block-editor-rich-text__editable';
+    private const FIRST_EDITABLE_PARAGRAPH = '.block-editor-block-list__layout [aria-label="Add block"]';
+
+    private const PRE_PUBLISH_BUTTON = '.editor-post-publish-panel__toggle';
+    private const PUBLISH_BUTTON = '.editor-post-publish-button';
+
+    private const VALIDATION_MESSAGE = '.components-snackbar';
+
+    private const SIDEBAR = '.block-editor-editor-skeleton__sidebar';
+}

--- a/tests/_support/Selector/Admin/GutenbergEditor/BlockName.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor/BlockName.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Selector\Admin\GutenbergEditor;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Blocks available in the block selector
+ * 
+ * @method static BlockName BUTTONS()
+ * @method static BlockName COUNTER()
+ * @method static BlockName CUSTOM_HTML()
+ * @method static BlockName DAILYMOTION()
+ * @method static BlockName EMBED()
+ * @method static BlockName FACEBOOK()
+ * @method static BlockName FILE()
+ * @method static BlockName FLICKR()
+ * @method static BlockName GALLERY()
+ * @method static BlockName HEADING()
+ * @method static BlockName IMAGE()
+ * @method static BlockName IMGUR()
+ * @method static BlockName INSTAGRAM()
+ * @method static BlockName ISSUU()
+ * @method static BlockName KICKSTARTER()
+ * @method static BlockName LIST()
+ * @method static BlockName MEETUP()
+ * @method static BlockName MIXCLOUD()
+ * @method static BlockName PARAGRAPH()
+ * @method static BlockName QUOTE()
+ * @method static BlockName REDDIT()
+ * @method static BlockName SCRIBD()
+ * @method static BlockName SEPARATOR()
+ * @method static BlockName SHORTCODE()
+ * @method static BlockName SLIDESHARE()
+ * @method static BlockName SOUNDCLOUD()
+ * @method static BlockName SPACER()
+ * @method static BlockName SPOTIFY()
+ * @method static BlockName SPREADSHEET()
+ * @method static BlockName TABLE()
+ * @method static BlockName TAKE_ACTION_BOXOUT()
+ * @method static BlockName TED()
+ * @method static BlockName TIMELINE()
+ * @method static BlockName TWITTER()
+ * @method static BlockName VIDEOPRESS()
+ * @method static BlockName VIMEO()
+ * @method static BlockName WORDPRESS()
+ * @method static BlockName YOUTUBE()
+ */
+class BlockName extends Enum
+{
+    private const BUTTONS = 'Buttons';
+    private const COUNTER = 'Counter';
+    private const CUSTOM_HTML = 'Custom HTML';
+    private const DAILYMOTION = 'Dailymotion';
+    private const EMBED = 'Embed';
+    private const FACEBOOK = 'Facebook';
+    private const FILE = 'File';
+    private const FLICKR = 'Flickr';
+    private const GALLERY = 'Gallery';
+    private const HEADING = 'Heading';
+    private const IMAGE = 'Image';
+    private const IMGUR = 'Imgur';
+    private const INSTAGRAM = 'Instagram';
+    private const ISSUU = 'Issuu';
+    private const KICKSTARTER = 'Kickstarter';
+    private const LIST = 'List';
+    private const MEETUP = 'Meetup.com';
+    private const MIXCLOUD = 'Mixcloud';
+    private const PARAGRAPH = 'Paragraph';
+    private const QUOTE = 'Quote';
+    private const REDDIT = 'Reddit';
+    private const SCRIBD = 'Scribd';
+    private const SEPARATOR = 'Separator';
+    private const SHORTCODE = 'Shortcode';
+    private const SLIDESHARE = 'Slideshare';
+    private const SOUNDCLOUD = 'Soundcloud';
+    private const SPACER = 'Spacer';
+    private const SPOTIFY = 'Spotify';
+    private const SPREADSHEET = 'Spreadsheet';
+    private const TABLE = 'Table';
+    private const TAKE_ACTION_BOXOUT = 'Take Action Boxout';
+    private const TED = 'TED';
+    private const TIMELINE = 'Timeline';
+    private const TWITTER = 'Twitter';
+    private const VIDEOPRESS = 'VideoPress';
+    private const VIMEO = 'Vimeo';
+    private const WORDPRESS = 'Wordpress';
+    private const YOUTUBE = 'YouTube';
+}

--- a/tests/_support/Selector/Admin/GutenbergEditor/BlockSection.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor/BlockSection.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Selector\Admin\GutenbergEditor;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Sections in the block selector
+ * 
+ * @method static BlockSection MOST_USED()
+ * @method static BlockSection P4_BLOCKS()
+ * @method static BlockSection P4_BLOCKS_BETA()
+ * @method static BlockSection COMMON_BLOCKS()
+ * @method static BlockSection FORMATTING()
+ * @method static BlockSection LAYOUT_ELEMENTS()
+ * @method static BlockSection WIDGETS()
+ * @method static BlockSection EMBEDS()
+ */
+class BlockSection extends Enum
+{
+    private const MOST_USED = 'Most used';
+    private const P4_BLOCKS = 'Planet 4 Blocks';
+    private const P4_BLOCKS_BETA = 'Planet 4 Blocks - BETA';
+    private const COMMON_BLOCKS = 'Common Blocks';
+    private const FORMATTING = 'Formatting';
+    private const LAYOUT_ELEMENTS = 'Layout Elements';
+    private const WIDGETS = 'Widgets';
+    private const EMBEDS = 'Embeds';
+}

--- a/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Selector\Admin\GutenbergEditor;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Selectors for the block selector
+ * 
+ * @method static BlockSelector MAIN_BUTTON()
+ */
+class BlockSelector extends Enum
+{
+    private const MAIN_BUTTON = '.components-button.block-editor-inserter__toggle';
+    private const SECTION = '//button[contains(@class, "components-button")][text()="%s"]';
+    private const BLOCK = '//ul[contains(@class, "block-editor-block-types-list")]//button/span[text()="%s"]';
+
+    public static function SECTION(BlockSection $sectionName): self
+    {
+        return new BlockSelector(sprintf(self::SECTION, (string) $sectionName));
+    }
+
+    public static function BLOCK(BlockName $blockName): self
+    {
+        return new BlockSelector(sprintf(self::BLOCK, (string) $blockName));
+    }
+
+    /**
+     * Check if is valid enum value
+     * Overwrites Enum method to allow for parameters in const
+     *
+     * @param $value
+     * @see Enum::isValid()
+     * @return bool
+     */
+    public static function isValid($value): bool
+    {
+        return true;
+    }
+}

--- a/tests/_support/Selector/Admin/GutenbergEditor/Sidebar.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor/Sidebar.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Selector\Admin\GutenbergEditor;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Selectors for the editor sidebar
+ * 
+ * @method static Sidebar TABS()
+ * @method static Sidebar DOCUMENT_TAB()
+ * @method static Sidebar BLOCK_TAB()
+ * @method static Sidebar ACTIVE_TAB()
+ */
+class Sidebar extends Enum
+{
+    private const TABS = '.edit-post-sidebar__panel-tabs';
+    private const DOCUMENT_TAB = '.edit-post-sidebar__panel-tab[data-label="Document"]';
+    private const BLOCK_TAB = '.edit-post-sidebar__panel-tab[data-label="Block"]';
+    private const ACTIVE_TAB = '.edit-post-sidebar__panel-tab.is_active';
+}

--- a/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
+++ b/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
@@ -1,0 +1,175 @@
+<?php
+namespace Step\Acceptance\Admin;
+
+use Page\Acceptance\Admin\GutenbergEditor;
+use Selector\Admin\GutenbergEditor as EditorSelector;
+use Selector\Admin\GutenbergEditor\BlockName;
+use Selector\Admin\GutenbergEditor\BlockSection;
+
+/**
+ * Gutenberg: steps to use Gutenberg editor
+ */
+class GutenbergEditorSteps
+{
+    /**
+     * @var \AcceptanceTester;
+     */
+    protected $tester;
+
+    /**
+     * @var GutenbergEditorPage
+     */
+    private $page;
+
+    public function __construct(
+        \AcceptanceTester $I,
+        GutenbergEditor $page
+    ) {
+        $this->tester = $I;
+        $this->page = $page;
+    }
+
+    /**
+     * @example I add a title "My title !"
+     * 
+     * @When I add a title :arg1
+     */
+    public function iAddATitle(string $title): void
+    {
+        $I = $this->tester;
+        $I->fillField(EditorSelector::TITLE_FIELD(), $title);
+    }
+
+    /**
+     * @When I add a paragraph :arg1
+     */
+    public function iAddAParagraph(?string $text): void
+    {
+        $I = $this->tester;
+
+        // New post starts with an empty paragraph block,
+        // if it is there, we use it
+        $firstParagraphExists = $I->checkIfElementExists(EditorSelector::FIRST_EDITABLE_PARAGRAPH());
+
+        if ($firstParagraphExists) {
+            $I->click(EditorSelector::FIRST_EDITABLE_PARAGRAPH());
+            $I->waitForElement(EditorSelector::EDITABLE_PARAGRAPH(), 1);
+        } else {
+            $this->iAddABlockFromSection('Paragraph', 'Common Blocks');
+            $I->waitForElement(EditorSelector::EDITABLE_PARAGRAPH(), 1);
+        }
+
+        if (null !== $text) {
+            $I->pressKey(EditorSelector::EDITABLE_PARAGRAPH(), $text);
+        }
+    }
+
+    /**
+     * @example I publish the post
+     * @example I publish the page
+     * 
+     * @When /I publish the (post|page)/
+     */
+    public function iPublishThePost(): void
+    {
+        $I = $this->tester;
+        $I->click(EditorSelector::PRE_PUBLISH_BUTTON());
+        $I->waitForElement(EditorSelector::PUBLISH_BUTTON(), 1);
+        $I->click(EditorSelector::PUBLISH_BUTTON());
+
+        // @todo: memorize new post id
+    }
+
+    /**
+     * @todo: paste does not currently work
+     * @see self::pasteText()
+     * @example I paste a video link "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+     * 
+     * @When I paste a video link :link
+     */
+    public function iPasteAYoutubeLink(string $link): void
+    {
+        $I = $this->tester;
+
+        $this->iAddABlockFromSection('YouTube', 'Embeds');
+        $I->waitForElement('.has-selected-ui[aria-label="Block: YouTube"] input[type="url"]', 1);
+        $I->pressKey('.has-selected-ui[aria-label="Block: YouTube"] input[type="url"]', $link);
+        $I->click('.has-selected-ui[aria-label="Block: YouTube"] button[type="submit"]');
+    }
+
+    /**
+     * @example I paste "Copy-pasta"
+     * 
+     * @When I paste :text
+     */
+    public function iPasteText(string $text): void
+    {
+        // @todo: paste does not currently work, 
+        // @todo: try ctrl+c or find out why chrome arg doesn't work
+        //$I = $this->tester;
+        //$I->executeJS('navigator.clipboard.writeText(arguments[0])', [$text]);
+        //$this->addParagraph($text);
+        //$I->pressKey('.block-editor-rich-text__editable', ['ctrl', 'v']);
+        throw new \Exception(__METHOD__ . ': not implemented.');
+    }
+
+    /**
+     * @example I add a block "YouTube" from section "Embeds"
+     * 
+     * @When I add a block :blockname from section :blocksection
+     */
+    public function iAddABlockFromSection(string $blockName, string $blockSection): void
+    {
+        $this->page->addBlock(
+            new BlockSection($blockSection),
+            new BlockName($blockName)
+        );
+    }
+
+    /**
+     * @When I open the block selector
+     */
+    public function iOpenTheBlockSelector(): void
+    {
+        $this->page->openBlockSelector();
+    }
+
+    /**
+     * @example I see a validation message
+     * @example I see a validation message "Post Published."
+     *
+     * @Then I see a validation message :message
+     */
+    public function iSeeAValidationMessage(?string $message): void
+    {
+        // @todo: check message content
+        $I = $this->tester;
+        $I->waitForElement((string) EditorSelector::VALIDATION_MESSAGE(), 10);
+    }
+
+    /**
+     * @Then the post is visible on the website
+     */
+    public function thePostIsVisibleOnTheWebsite(): void
+    {
+        // @todo: memorize post id to visit
+    }
+
+    /**
+     * @Then I see the video in the editor
+     */
+    public function iSeeTheVideoInTheEditor(): void
+    {
+        // @todo: get reference to video inserted
+        $I = $this->tester;
+        $I->waitForElement('figure.is-type-video iframe');
+    }
+
+    /**
+     * @Then I see the video in the post published
+     */
+    public function iSeeTheVideoInThePostPublished(): void
+    {
+        // @todo: memorize post id to visit
+    }
+}

--- a/tests/_support/Step/Acceptance/Admin/NavigationSteps.php
+++ b/tests/_support/Step/Acceptance/Admin/NavigationSteps.php
@@ -1,0 +1,55 @@
+<?php
+namespace Step\Acceptance\Admin;
+
+use Page\Acceptance\Admin\Navigation;
+
+/**
+ * Navigation: steps for navigating in admin interface
+ */
+class NavigationSteps
+{
+    /**
+     * @var \AcceptanceTester;
+     */
+    protected $tester;
+
+    /**
+     * @var GutenbergEditorPage
+     */
+    private $page;
+
+    public function __construct(
+        \AcceptanceTester $I
+    ) {
+        $this->tester = $I;
+    }
+
+    /**
+     * @example I navigate to "Posts > Add new"
+     * 
+     * @When I navigate to :pagepath
+     */
+    public function iNavigateTo(string $pagepath): void
+    {
+        $I = $this->tester;
+        $I->amOnPage(Navigation::pageLink($pagepath));
+    }
+
+    /**
+     * @Given I open the dashboard
+     */
+    public function iOpenTheDashboard(): void
+    {
+        $I = $this->tester;
+        $I->amOnPage(Navigation::pageLink('Dashboard'));
+    }
+
+    /**
+     * @Given I am on a new post page
+     */
+    public function iAmOnANewPostPage(): void
+    {
+        $I = $this->tester;
+        $I->amOnPage(Navigation::pageLink('Posts > Add New'));
+    }
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -37,6 +37,9 @@ modules:
             adminPassword: '%TEST_SITE_ADMIN_PASSWORD%'
             adminPath: '%TEST_SITE_WP_ADMIN_PATH%'
             clear_cookies: true
+            capabilities:
+                chromeOptions:
+                    args: ["--unsafely-treat-insecure-origin-as-secure='%TEST_SITE_WP_URL%'"]
         WPCLI:
             path: /app/source/public
             throw: true
@@ -47,3 +50,9 @@ extensions:
         Codeception\Extension\Recorder:
             delete_successful: true
             module: WPWebDriver
+gherkin:
+    contexts:
+        default:
+            - AcceptanceTester
+            - Step\Acceptance\Admin\NavigationSteps
+            - Step\Acceptance\Admin\GutenbergEditorSteps

--- a/tests/acceptance/editor.feature
+++ b/tests/acceptance/editor.feature
@@ -1,0 +1,24 @@
+Feature: editor basics
+  In order to publish content
+  As a logged in admin
+  I need to be able to use the editor
+
+Background:
+  Given I am logged in as administrator
+  And I open the dashboard
+
+  Scenario: Create a new post
+    Given I am on a new post page
+    When I add a title "Test title"
+    And I add a paragraph "Test paragraph"
+    And I publish the post
+    Then I see a validation message "Post published."
+    And the post is visible on the website
+
+  Scenario: Add a youtube video in a post
+    Given I am on a new post page
+    When I add a title "Test video"
+    And I paste a video link "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    And I publish the post
+    Then I see the video in the editor
+    And I see the video in the post published

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -19,7 +19,8 @@
 		"github-protocols": ["https"]
 	},
 	"require-dev": {
-    "codeception/c3": "^2.4.1",
-		"lucatume/wp-browser": "^2.6.1"
+		"codeception/c3": "^2.4.1",
+		"lucatume/wp-browser": "^2.6.1",
+		"myclabs/php-enum": "^1.7"
 	}
 }

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75bdd419ae61c21b15f1664e6d20af4f",
+    "content-hash": "aabdc8c56b0334380154f07efab85366",
     "packages": [
         {
             "name": "behat/gherkin",
@@ -602,20 +602,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.5",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "replace": {
                 "myclabs/deep-copy": "self.version"
@@ -646,7 +646,13 @@
                 "object",
                 "object graph"
             ],
-            "time": "2020-01-17T21:11:47+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-29T13:22:24+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -817,25 +823,25 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -862,7 +868,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2020-04-27T09:25:28+00:00"
+            "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -919,30 +925,29 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
+                "php": "^7.2 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.2",
-                "mockery/mockery": "~1"
+                "ext-tokenizer": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-1.x": "1.x-dev"
                 }
             },
             "autoload": {
@@ -961,7 +966,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-02-18T18:59:58+00:00"
+            "time": "2020-06-27T10:12:23+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1280,16 +1285,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.5",
+            "version": "8.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "63dda3b212a0025d380a745f91bdb4d8c985adb7"
+                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/63dda3b212a0025d380a745f91bdb4d8c985adb7",
-                "reference": "63dda3b212a0025d380a745f91bdb4d8c985adb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/34c18baa6a44f1d1fbf0338907139e9dce95b997",
+                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997",
                 "shasum": ""
             },
             "require": {
@@ -1359,7 +1364,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-05-22T13:51:52+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-06-22T07:06:58+00:00"
         },
         {
             "name": "psr/container",
@@ -2163,16 +2178,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "00bed125812716d09b163f0727ef33bb49bf3448"
+                "reference": "34ac555a3627e324b660e318daa07572e1140123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/00bed125812716d09b163f0727ef33bb49bf3448",
-                "reference": "00bed125812716d09b163f0727ef33bb49bf3448",
+                "url": "https://api.github.com/repos/symfony/console/zipball/34ac555a3627e324b660e318daa07572e1140123",
+                "reference": "34ac555a3627e324b660e318daa07572e1140123",
                 "shasum": ""
             },
             "require": {
@@ -2238,11 +2253,25 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-05-30T20:35:19+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-15T12:59:21+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -2291,6 +2320,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -2341,7 +2384,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -2409,6 +2452,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -2471,7 +2528,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2516,20 +2573,34 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
                 "shasum": ""
             },
             "require": {
@@ -2542,6 +2613,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2574,20 +2649,34 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-05-12T16:14:59+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "e094b0770f7833fdf257e6ba4775be4e258230b2"
+                "reference": "6e4dbcf5e81eba86e36731f94fe56b1726835846"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e094b0770f7833fdf257e6ba4775be4e258230b2",
-                "reference": "e094b0770f7833fdf257e6ba4775be4e258230b2",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/6e4dbcf5e81eba86e36731f94fe56b1726835846",
+                "reference": "6e4dbcf5e81eba86e36731f94fe56b1726835846",
                 "shasum": ""
             },
             "require": {
@@ -2600,6 +2689,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2634,20 +2727,34 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "1357b1d168eb7f68ad6a134838e46b0b159444a9"
+                "reference": "40309d1700e8f72447bb9e7b54af756eeea35620"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/1357b1d168eb7f68ad6a134838e46b0b159444a9",
-                "reference": "1357b1d168eb7f68ad6a134838e46b0b159444a9",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/40309d1700e8f72447bb9e7b54af756eeea35620",
+                "reference": "40309d1700e8f72447bb9e7b54af756eeea35620",
                 "shasum": ""
             },
             "require": {
@@ -2660,6 +2767,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2697,20 +2808,34 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-05-12T16:14:59+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-14T14:40:37+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c"
+                "reference": "7110338d81ce1cbc3e273136e4574663627037a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fa79b11539418b02fc5e1897267673ba2c19419c",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7110338d81ce1cbc3e273136e4574663627037a7",
+                "reference": "7110338d81ce1cbc3e273136e4574663627037a7",
                 "shasum": ""
             },
             "require": {
@@ -2723,6 +2848,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2756,20 +2885,34 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a760d8964ff79ab9bf057613a5808284ec852ccc"
+                "reference": "fa0837fe02d617d31fbb25f990655861bb27bd1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a760d8964ff79ab9bf057613a5808284ec852ccc",
-                "reference": "a760d8964ff79ab9bf057613a5808284ec852ccc",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fa0837fe02d617d31fbb25f990655861bb27bd1a",
+                "reference": "fa0837fe02d617d31fbb25f990655861bb27bd1a",
                 "shasum": ""
             },
             "require": {
@@ -2779,6 +2922,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2814,20 +2961,34 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd"
+                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/5e30b2799bc1ad68f7feb62b60a73743589438dd",
-                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4a5b6bba3259902e386eb80dd1956181ee90b5b2",
+                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2",
                 "shasum": ""
             },
             "require": {
@@ -2837,6 +2998,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2876,11 +3041,25 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.9",
+            "version": "v4.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -2925,6 +3104,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T20:06:45+00:00"
         },
         {
@@ -2987,16 +3180,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "90c2a5103f07feb19069379f3abdcdbacc7753a9"
+                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/90c2a5103f07feb19069379f3abdcdbacc7753a9",
-                "reference": "90c2a5103f07feb19069379f3abdcdbacc7753a9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ac70459db781108db7c6d8981dd31ce0e29e3298",
+                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298",
                 "shasum": ""
             },
             "require": {
@@ -3054,11 +3247,25 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-11T12:16:36+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -3117,6 +3324,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -3161,16 +3382,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
                 "shasum": ""
             },
             "require": {
@@ -3178,6 +3399,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
+                "phpstan/phpstan": "<0.12.20",
                 "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
@@ -3205,7 +3427,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-04-18T12:12:48+00:00"
+            "time": "2020-06-16T10:16:42+00:00"
         }
     ],
     "packages-dev": [
@@ -3361,16 +3583,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.10.7",
+            "version": "1.10.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "956608ea4f7de9e58c53dfb019d85ae62b193c39"
+                "reference": "56e0e094478f30935e9128552188355fa9712291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/956608ea4f7de9e58c53dfb019d85ae62b193c39",
-                "reference": "956608ea4f7de9e58c53dfb019d85ae62b193c39",
+                "url": "https://api.github.com/repos/composer/composer/zipball/56e0e094478f30935e9128552188355fa9712291",
+                "reference": "56e0e094478f30935e9128552188355fa9712291",
                 "shasum": ""
             },
             "require": {
@@ -3389,12 +3611,11 @@
                 "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0"
             },
             "conflict": {
-                "symfony/console": "2.8.38",
-                "symfony/phpunit-bridge": "3.4.40"
+                "symfony/console": "2.8.38"
             },
             "require-dev": {
                 "phpspec/prophecy": "^1.10",
-                "symfony/phpunit-bridge": "^3.4"
+                "symfony/phpunit-bridge": "^4.2"
             },
             "suggest": {
                 "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
@@ -3438,7 +3659,21 @@
                 "dependency",
                 "package"
             ],
-            "time": "2020-06-03T08:03:56+00:00"
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-24T19:23:30+00:00"
         },
         {
             "name": "composer/semver",
@@ -3935,7 +4170,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v7.15.0",
+            "version": "v7.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -3979,16 +4214,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v7.15.0",
+            "version": "v7.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "6fffd3f2a1d81fa29682eac43ef8701073c4214d"
+                "reference": "68b0f13940bdea9e57b1c5485a1f498934e43a23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/6fffd3f2a1d81fa29682eac43ef8701073c4214d",
-                "reference": "6fffd3f2a1d81fa29682eac43ef8701073c4214d",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/68b0f13940bdea9e57b1c5485a1f498934e43a23",
+                "reference": "68b0f13940bdea9e57b1c5485a1f498934e43a23",
                 "shasum": ""
             },
             "require": {
@@ -4037,7 +4272,7 @@
             ],
             "description": "The Illuminate Support package.",
             "homepage": "https://laravel.com",
-            "time": "2020-06-08T02:42:53+00:00"
+            "time": "2020-06-23T15:40:58+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -4107,16 +4342,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "96085964d4f92ef9c5db05876977cc652353fc40"
+                "reference": "83fc32b65ba4720ba07c41109cc5d9348085d210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/96085964d4f92ef9c5db05876977cc652353fc40",
-                "reference": "96085964d4f92ef9c5db05876977cc652353fc40",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/83fc32b65ba4720ba07c41109cc5d9348085d210",
+                "reference": "83fc32b65ba4720ba07c41109cc5d9348085d210",
                 "shasum": ""
             },
             "require": {
@@ -4186,20 +4421,20 @@
                 "codeception",
                 "wordpress"
             ],
-            "time": "2020-06-11T09:31:08+00:00"
+            "time": "2020-06-19T08:46:27+00:00"
         },
         {
             "name": "mck89/peast",
-            "version": "v1.10.3",
+            "version": "v1.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "6d1100f39f684c9e004f808b27f6c824b083d8d8"
+                "reference": "e11664ef53ba2a4ca1d16d8bc73fcc317cd65d3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/6d1100f39f684c9e004f808b27f6c824b083d8d8",
-                "reference": "6d1100f39f684c9e004f808b27f6c824b083d8d8",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/e11664ef53ba2a4ca1d16d8bc73fcc317cd65d3d",
+                "reference": "e11664ef53ba2a4ca1d16d8bc73fcc317cd65d3d",
                 "shasum": ""
             },
             "require": {
@@ -4211,7 +4446,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.3-dev"
+                    "dev-master": "1.10.4-dev"
                 }
             },
             "autoload": {
@@ -4231,7 +4466,7 @@
                 }
             ],
             "description": "Peast is PHP library that generates AST for JavaScript code",
-            "time": "2020-04-03T09:06:20+00:00"
+            "time": "2020-06-21T17:16:08+00:00"
         },
         {
             "name": "mikemclin/laravel-wp-password",
@@ -4342,6 +4577,52 @@
                 "templating"
             ],
             "time": "2019-11-23T21:40:31+00:00"
+        },
+        {
+            "name": "myclabs/php-enum",
+            "version": "1.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "time": "2020-02-14T08:15:52+00:00"
         },
         {
             "name": "nb/oxymel",
@@ -4696,7 +4977,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.41",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -4742,11 +5023,25 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T17:48:24+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -4820,6 +5115,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T20:35:19+00:00"
         },
         {
@@ -4881,16 +5190,16 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "e7f9bd5deff09a57318f9b900ab33a05acfcf4d3"
+                "reference": "618631dc601d8eb6ea0a9fbf654ec82f066c4e97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/e7f9bd5deff09a57318f9b900ab33a05acfcf4d3",
-                "reference": "e7f9bd5deff09a57318f9b900ab33a05acfcf4d3",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/618631dc601d8eb6ea0a9fbf654ec82f066c4e97",
+                "reference": "618631dc601d8eb6ea0a9fbf654ec82f066c4e97",
                 "shasum": ""
             },
             "require": {
@@ -4925,7 +5234,25 @@
                 "clean",
                 "php"
             ],
-            "time": "2020-05-26T06:40:44+00:00"
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-ascii",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-15T23:49:30+00:00"
         },
         {
             "name": "vria/nodiacritic",
@@ -7000,5 +7327,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Refs:
- https://jira.greenpeace.org/browse/PLANET-5167
- https://jira.greenpeace.org/browse/PLANET-5168
- https://jira.greenpeace.org/browse/PLANET-5169

Follow-up of PoC: [PoC for BDD tests #77](https://github.com/greenpeace/planet4-base-fork/pull/77)  

## _A short reminder about Gherkin_ 
This PR implements tests in a [Gherkin](https://cucumber.io/docs/gherkin/reference/) format, run by [Codeception](https://codeception.com/docs/07-BDD#Gherkin).  
By implementing reusable sentences and making available a documented list of those, we can try to reach a point where a tester (non-coder) writes a feature file that is playable as is, without any technical intervention. Even if this goal is not fully reached, this might greatly help with tests readability and organization for the whole team.  

Tests look like this (keywords hilighted in red, parameters quoted):
```gherkin
Scenario: Create a new post
    Given I am on a new post page
    When I add a title "Test title"
    And I publish the post
    Then a message "Post published." is displayed
```
Implementation looks like this (sentences are matched by annotations `@Given`, `@When`, `@Then`):
```php

    /**
     * @example I add a title "My title !"
     * 
     * @When I add a title :arg1
     */
    public function iAddATitle(string $title): void
    {
        $I = $this->tester;
        $I->fillField(EditorSelector::TITLE_FIELD(), $title);
    }
```


## What changed since #77 

- Selectors moved into constants. I'm using [myclabs/phpenum](https://github.com/myclabs/php-enum) for this:
  - it makes it easy to add variable parts to those strings, as everything is called like a static method
  - it gives some helpers to list all keys and values
  - it allows to type constants, making it possible to lock usage of some functions to only a specific type of constant, and fail faster and with a more obvious error message (for example, `GutenbergEditor::addBlock` can only take `BlockSection` and `BlockName` as params and will say so if failing, which is more explicit than failing because the selector was not found in the page)
- Method names follow more closely the sentence they describe. I'm not completely satisfied by what codeception generates, but we can also make our own name generator if we feel the need to.
- Steps (methods described with `Given` `When` and `Then`) were moved to `Step\` namespace
- `Page\` namespace is used for interactions with pages that are not steps but that can be used by steps
  - In those interactions, we can more tightly limit parameter types and make tests wrongly implemented fail faster
- 2 commands were added to facilitate development and sharing of vocabulary

### Commands

`p4:selectors`  
- lists the available selectors, ordered by class. Class name should be explicit enough.  _Classes currently have to be added to the command code, we should add a file scan later if needed._
- variable parts of the selectors are highlighted.
<img width="863" alt="Screenshot 2020-06-29 at 14 49 31" src="https://user-images.githubusercontent.com/617346/86115532-60e5f780-bacc-11ea-85f5-21cd8a88e9af.png">

`p4:steps <suite> [-i]`  
- lists the available steps, with examples if possible (examples are method annotations `@example`)
- sorted by Step files, with a short description (description taken from class comments)
- option `-i` displays the `class::method` implementing the sentence
<img width="880" alt="Screenshot 2020-06-29 at 14 49 57" src="https://user-images.githubusercontent.com/617346/86115543-65121500-bacc-11ea-966c-be34e26917a1.png">

## Test

Tests passed in the CI :https://app.circleci.com/pipelines/github/greenpeace/planet4-base-fork/452/workflows/8e5b6c62-e0c4-437e-a4f5-5217fea3dac0/jobs/5075/steps. 
Run it locally with `tests/vendor/bin/codecept run -vv acceptance editor.feature`

### Review guide

- `tests/__support/Command`
The two commands added, started by copying `Codeception\Command\GherkinSteps`
- `tests/__support/Selector`
All selectors, grouped by zone as `Enum`
- `tests/__support/Step`
All steps, grouped by topic/zone
- `tests/__support/Page`
Pages interactions not declared as steps (for internal use, type hinting, etc.)
- Added commands to `codeception.yml`, added steps to `acceptance.suite.yml`

### Next
- In time we should automate an export of `p4:steps` to make it always available and up to date for test writers.
- Add string interpolation to constants instead of just `%s`
- Some scenarios need context to continue (a post id just created for example), find a clean way to handle that. (It is in part why there is no public site check at the moment, I'm waiting to have a few more tests to see how to group that)
- Tests are slow, some scenarios should be grouped by chaining `when-then` in the same scenario
- Commands code might deserve a bit of cleanup
- Still did not solve this copy/paste problem (not a priority)