### PR TITLE
Remove plugin gutenberg-en since it was removed from composer

### DIFF
--- a/tasks/other/install-deps.sh
+++ b/tasks/other/install-deps.sh
@@ -6,7 +6,7 @@ npm run build
 composer install
 popd || exit
 
-for plugin in gutenberg-blocks gutenberg-engagingnetworks
+for plugin in gutenberg-blocks
 do
 	pushd /app/source/public/wp-content/plugins/planet4-plugin-${plugin} || exit
 	npm install

--- a/tasks/other/install-deps.sh
+++ b/tasks/other/install-deps.sh
@@ -6,11 +6,9 @@ npm run build
 composer install
 popd || exit
 
-for plugin in gutenberg-blocks
-do
-	pushd /app/source/public/wp-content/plugins/planet4-plugin-${plugin} || exit
-	npm install
-	npm run build
-	composer install
-	popd || exit
-done
+pushd /app/source/public/wp-content/plugins/planet4-plugin-gutenberg-blocks || exit
+npm install
+npm run build
+composer install
+popd || exit
+


### PR DESCRIPTION
Since the plugin-gutenberg-engaging-networks was removed from the composer.json (at this [commit](https://github.com/greenpeace/planet4-base-fork/commit/61c7b39c70a0095c8cc58732eb1f810c7bf2b184) ) , the installation script of planet4-docker-compose was failing with: 
```
Generating autoload files
PHP CodeSniffer Config installed_paths set to ../../wp-coding-standards/wpcs
/app/source
/app/source/tasks/other/install-deps.sh: line 11: pushd: /app/source/public/wp-content/plugins/planet4-plugin-gutenberg-engagingnetworks: No such file or directory
make: *** [repos] Error 1
```

The current commit removes the failing dependancy