### PR TITLE
PLANET-5343: Fix test for columns_tasks modification

### DIFF
--- a/tests/acceptance/ColumnsTasksCept.php
+++ b/tests/acceptance/ColumnsTasksCept.php
@@ -42,5 +42,5 @@ $I->see( 'Tasks Columns', 'h2' );
 $I->see( 'Columns Block description', 'div' );
 $I->see( 'Column 1', '.step-info h5' );
 $I->see( 'Column 1 description', '.step-info p' );
-$I->seeElement( '.steps-action img' );
-$I->see( 'Explore', '.steps-action a.btn-secondary' );
+$I->seeElement( '.steps-action img, .step-info img' );
+$I->see( 'Explore', '.steps-action a.btn-secondary, .step-info a.btn-secondary' );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5343
Depends on https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/342

Modification of a test to fit the new `columns_tasks` template markup.