### PR TITLE
PLANET-5275: Add pa11y configuration for accessibility report

### DIFF
--- a/pa11y/.gitignore
+++ b/pa11y/.gitignore
@@ -1,0 +1,3 @@
+!.gitignore
+!.pa11yci
+!.pa11yci.local

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -1,0 +1,19 @@
+{
+    "defaults": {
+        "timeout": 30000,
+        "viewport": {
+            "width": 1200,
+            "height": 800
+        },
+        "chromeLaunchConfig": {
+            "ignoreHTTPSErrors": true,
+            "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+        },
+        "includeWarnings": true,
+        "includeNotices": true
+    },
+    "urls": [
+        "http://www.planet4.test/",
+        "http://www.planet4.test/?s="
+    ]
+}

--- a/pa11y/.pa11yci.local
+++ b/pa11y/.pa11yci.local
@@ -1,0 +1,19 @@
+{
+    "defaults": {
+        "timeout": 30000,
+        "viewport": {
+            "width": 1200,
+            "height": 800
+        },
+        "chromeLaunchConfig": {
+            "ignoreHTTPSErrors": true,
+            "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+        },
+        "includeWarnings": false,
+        "includeNotices": false
+    },
+    "urls": [
+        "http://www.planet4.test/",
+        "http://www.planet4.test/?s="
+    ]
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5275
Ref: https://github.com/greenpeace/planet4/issues/73

Related to: https://github.com/greenpeace/planet4-docker-compose/pull/52 (targets to run pa11y)  
Related to: https://github.com/greenpeace/planet4-master-theme/pull/1165 (run on master-theme)

Configuration of [pa11y](https://github.com/pa11y/pa11y) to generate an accessibility report.

The configuration includes warnings and notices to produce a comprehensive report. The CI decides if the job should fail or not, based on the presence of errors in the report.  
Viewport is arbitrary, we could try multiple sizes to check that our elements stay accessible at mobile size for example.  

A local config is included, as a default and example for running the test in local dev environment.

Arguments `["--no-sandbox", "--disable-setuid-sandbox"]` are there to be able to [launch chromium with puppeteer](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox) on Debian.

For more configuration details see https://github.com/pa11y/pa11y-ci#configuration and https://github.com/pa11y/pa11y#configuration