### PR TITLE
PLANET-5373 Fix custom taxonomy page test to match author name w/o "by" string

### DIFF
--- a/tests/acceptance/CustomTaxonomyPageCept.php
+++ b/tests/acceptance/CustomTaxonomyPageCept.php
@@ -30,6 +30,6 @@ $postID = $I->havePostInDatabase([
 ]);
 
 // Navigate to the newly created post
-$I->amOnPage('/issues/people/' . $postID);
+$I->amOnPage('/story/' . $postID);
 
-$I->see('by FooBarAuthor', 'address');
+$I->see('FooBarAuthor', 'address');


### PR DESCRIPTION
Related to [JIRA 5373](https://jira.greenpeace.org/browse/PLANET-5373)

- Remove "by" string from author name
- Update post Navigation path 

Related PR [#1199](https://github.com/greenpeace/planet4-master-theme/pull/1199)