### PR TITLE
PLANET-5517 Script to turn off ElasticPress features

### DIFF
--- a/tasks/post-deploy/04-disable-ep-features.sh
+++ b/tasks/post-deploy/04-disable-ep-features.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Disable some ElasticPress plugin features that don't work for us and affect performance.
+wp elasticpress deactivate-feature facets
+wp elasticpress deactivate-feature related_posts


### PR DESCRIPTION
Using a post-deploy script so we can use ElasticPress's CLI commands. It can be removed again after it has run on all NROs once.

Ref: https://jira.greenpeace.org/browse/PLANET-5517