### PR TITLE
PLANET-5661 Upgrade wp-stateless to 3.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.0.*",
     "wpackagist-plugin/wp-sentry-integration":"3.*",
-    "wpackagist-plugin/wp-stateless": "2.*"
+    "wpackagist-plugin/wp-stateless": "3.1.*"
   },
 
   "config": {


### PR DESCRIPTION
Tested locally but also it in a multilingual site. Didn't notice any issue. Their Changelog also doesn't mention any breaking change. It's mostly bug fixing, compatibility with other plugins and wp-cli improvements.