### PR TITLE
PLANET-5619 Add Cloudflare plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "greenpeace/planet4-plugin-medialibrary" : "dev-master",
     "wikimedia/composer-merge-plugin": "1.4.1",
     "wpackagist-plugin/akismet": "4.*",
-    "wpackagist-plugin/cloudflare" : "3.8.5",
+    "wpackagist-plugin/cloudflare" : "3.8.6",
     "wpackagist-plugin/duplicate-post": "3.*",
     "wpackagist-plugin/elasticpress":"3.5.*",
     "wpackagist-plugin/gdpr-comments":"1.0.2",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "greenpeace/planet4-plugin-medialibrary" : "dev-master",
     "wikimedia/composer-merge-plugin": "1.4.1",
     "wpackagist-plugin/akismet": "4.*",
+    "wpackagist-plugin/cloudflare" : "3.8.5",
     "wpackagist-plugin/duplicate-post": "3.*",
     "wpackagist-plugin/elasticpress":"3.5.*",
     "wpackagist-plugin/gdpr-comments":"1.0.2",

--- a/tasks/post-deploy/01-run-p4-activator.sh
+++ b/tasks/post-deploy/01-run-p4-activator.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-# Instantiate P4_Activator and run its functions.
 # This will trigger planet4-master-theme activation/deactivation hooks.
 # It is meant for running one-off actions like adding custom roles and capabilities.
 if ( wp theme is-active planet4-master-theme ) || ( wp theme status | grep -q 'P planet4-master-theme' )  then

--- a/tasks/post-deploy/04-save-cf-key.sh
+++ b/tasks/post-deploy/04-save-cf-key.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+wp p4-cf-key-in-db "${APP_HOSTNAME}"
+
+wp plugin activate cloudflare


### PR DESCRIPTION
Add Cloudflare plugin which will do cache invalidation once we turn on APO.

~~Still to sort out: the plugin expects the API key in WP options. We probably want to add this as a secret in CircleCI and set up a way to safely put it in the DB, so that rotating the key is simple.~~ For now we put the key in `wp-config.php` the same way as other secrets are. Then we run a post-deploy script to put the key where the plugin expects it in the `wp_options` table. I already included this script in this PR so we need to merge that PR first https://github.com/greenpeace/planet4-master-theme/pull/1240