### PR TITLE
Add 3rdparty plugins as packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,50 @@
     {
       "type": "composer",
       "url": "https://packagist.org"
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "wpml/multilingual-cms",
+        "version": "4.3.12",
+        "dist": {
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.3.12.zip",
+          "type": "zip"
+        }
+      }
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "wpml/translation-management",
+        "version": "2.9.6",
+        "dist": {
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-translation-management.2.9.6.zip",
+          "type": "zip"
+        }
+      }
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "wpml/string-translation",
+        "version": "3.0.9",
+        "dist": {
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-string-translation.3.0.9.zip",
+          "type": "zip"
+        }
+      }
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "ideapush/ideapush",
+        "version": "7.19",
+        "dist": {
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/ideapush-v7.19.zip",
+          "type": "zip"
+        }
+      }
     }
   ],
 


### PR DESCRIPTION
Inspired by your idea in [this branch](https://github.com/greenpeace/planet4-base-fork/compare/shared-plugin-defs), I thought we could use the native composer way of including packages from a zip url.

Having that in place, we can then remove versions from NRO repos and have just a singe line with a wildcard ([example](https://github.com/greenpeace/planet4-test-saturn/blob/4f5d9fa7dfb4482dd5ad9cf1a771de7fe1eaf796/composer-local.json#L21)).

We can merge it on `develop` first and test it on a NRO dev instance, although it worked fine on the test instance.