### PR TITLE
PLANET-5705 Fix EN tests to use proper selector for checkboxes

### DIFF
--- a/tests/acceptance/ENFormCest.php
+++ b/tests/acceptance/ENFormCest.php
@@ -381,7 +381,7 @@ class ENFormCest {
 				$user_form_data['supporter']['questions'][ 'question.' . $form_field['id'] ] = 'Lorem ipsum';
 			} else if ( 'Checkbox' === $field_type ) {
 				$user_form_data['supporter']['questions'][ 'question.' . $form_field['id'] ] = 'Y';
-				$I->click('.en__field--' . $form_field['id'] . ' > .en__field__element--check');
+				$I->click('.en__field--' . $form_field['id'] . ' .custom-control-description');
 			}
 		}
 
@@ -495,7 +495,7 @@ class ENFormCest {
 				$user_form_data['supporter']['questions'][ 'question.' . $form_field['id'] ] = 'Lorem ipsum';
 			} else if ( 'Checkbox' === $field_type ) {
 				$user_form_data['supporter']['questions'][ 'question.' . $form_field['id'] ] = 'Y';
-				$I->click('.en__field--' . $form_field['id'] . ' > .en__field__element--check');
+				$I->click('.en__field--' . $form_field['id'] . ' .custom-control-description');
 			}
 		}
 
@@ -609,7 +609,7 @@ class ENFormCest {
 			} else if ( 'Checkbox' === $field_type ) {
 				$user_form_data['supporter']['questions'][ 'question.' . $form_field['id'] ] = 'Y';
 				$I->scrollTo('.en__field--' . $form_field['id']);
-				$I->click('.en__field--' . $form_field['id'] . ' > .en__field__element--check');
+				$I->click('.en__field--' . $form_field['id'] . ' .custom-control-description');
 			}
 		}
 


### PR DESCRIPTION
We added a `pointer-events` css property in greenpeace/planet4-styleguide#87, so only the input description is clickable, instead of the whole div.