### PR TITLE
rsync: omit times to avoid some errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,8 +138,8 @@
     "reset:plugins" : "rm -rf public/wp-content/plugins",
 
     "download:wordpress": "wp core download --version=5.0.3 --path=public --force",
-    "copy:plugins" : "rsync -ar vendor/plugins public/wp-content",
-    "copy:themes" : "rsync -ar vendor/themes public/wp-content",
+    "copy:plugins" : "rsync -arOJ vendor/plugins public/wp-content",
+    "copy:themes" : "rsync -arOJ vendor/themes public/wp-content",
 
     "redis:enable" : "wp redis enable",
 


### PR DESCRIPTION
On some specific configurations, `rsync` can fail for symlinks with an error message about setting times
> rsync: failed to set times on "/app/source/public/wp-content/plugins/planet4-plugin-gutenberg-blocks/languages/planet4-blocks-backend-nl_BE-planet4-blocks-script.json": No such file or directory (2) 
> rsync error: some files/attrs were not transferred (see previous errors) 

This error will then stop the installation of the dev environment.

The error could be linked to [FUSE](https://github.com/libfuse/libfuse) or just a difference in filesystems.  
Adding options [`-O` and `-J`](https://ss64.com/bash/rsync_options.html) will stop rsync from trying to preserve modification times for directories and symlinks. While I couldn't reproduce the problem, it has worked for the faulty system, and has not introduced any problem on my other configurations.

### Side note

I think these rsync could be replaced by a better configuration of `installer-paths` but my replacement fails in CI, so this fix stays relevant for now.