### PR TITLE
Revert "PLANET-5661 Upgrade wp-stateless to 3.1.x"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.1.*",
     "wpackagist-plugin/wp-sentry-integration":"3.*",
-    "wpackagist-plugin/wp-stateless": "3.1.*"
+    "wpackagist-plugin/wp-stateless": "2.*"
   },
 
   "config": {


### PR DESCRIPTION
This reverts commit ac2b083245f72e5d26d9415a525b7976e37ce9f9.

Campaign importer is not working with 3.x, we can go back to 2.x while we find a fix.