### PR TITLE
Add -60px Y offset to clear fixed navbar

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -7,8 +7,9 @@ use tad\WPBrowser\Generators\Date;
  */
 class AcceptanceTester extends \Codeception\Actor
 {
-	use _generated\AcceptanceTesterActions;
-
+  use _generated\AcceptanceTesterActions {
+    scrollTo as baseScrollTo;
+  }
 
 	/**
 	 * A simple helper to fill in a form without repetitively calling `$I->fillField()`
@@ -98,4 +99,13 @@ class AcceptanceTester extends \Codeception\Actor
 		$I = $this;
 		$I->dontHaveCommentInDatabase(['comment_author_email' => $email]);
 	}
+
+  /**
+   * Add 60 offset if not provided, to avoid fixed top nav covering the element and possibly obstructing clicks.
+   *
+   * @inheritDoc
+   */
+  public function scrollTo( $selector, $offsetX = null, $offsetY = null ) {
+    return $this->baseScrollTo($selector, $offsetX, $offsetY ?? -60);
+  }
 }


### PR DESCRIPTION
This should make acceptance tests pass again. The navbar was not cleared by the scroll, so sometimes it covered an element that needs to be clicked by the test. We always have this navbar so makes sense to always add the offset.

The code of the affected test hadn't changed, but there are some new notices caused by some autoloading issues of the Cloudflare plugin. Before these notices it couldn't scroll far enough for the navbar to cover the checkbox.

We can probably disable the Cloudflare plugin when running acceptance tests.