### PR TITLE
PLANET-5523 Update acceptance tests for Covers WYSIWYG conversion

### DIFF
--- a/tests/acceptance/CoversCampaignCept.php
+++ b/tests/acceptance/CoversCampaignCept.php
@@ -13,9 +13,9 @@ $I->havePageInDatabase([
 	'post_content' => $I->generateGutenberg('wp:planet4-blocks/covers', [
 		'cover_type'  => '2',
 		'title'       => 'Campaign',
-		'tags'        => '6,20',
+		'tags'        => [6, 20],
 		'description' => 'Description text',
-		'covers_view' => '0'
+		'covers_view' => '1'
 	])
 ]);
 

--- a/tests/acceptance/CoversContentCept.php
+++ b/tests/acceptance/CoversContentCept.php
@@ -13,9 +13,9 @@ $I->havePageInDatabase([
 	'post_content' => $I->generateGutenberg('wp:planet4-blocks/covers', [
 		'cover_type'  => '3',
 		'title'       => 'Content',
-		'tags'        => '7',
+		'tags'        => [7],
 		'description' => 'Description text',
-		'covers_view' => '0'
+		'covers_view' => '1'
 	])
 ]);
 

--- a/tests/acceptance/CoversTakeActionCept.php
+++ b/tests/acceptance/CoversTakeActionCept.php
@@ -15,7 +15,7 @@ $I->havePageInDatabase([
 		'title'       => 'Take Action',
 		'tags'        => [6, 20],
 		'description' => 'Description text',
-		'covers_view' => '0'
+		'covers_view' => '1'
 	])
 ]);
 


### PR DESCRIPTION
## Description

See [PLANET-5523](https://jira.greenpeace.org/browse/PLANET-5523)

There is a follow-up ticket to add JS acceptance tests for this block: [PLANET-5915](https://jira.greenpeace.org/browse/PLANET-5915)

Corresponding gutenberg-blocks PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/486