### PR TITLE
Revert repos branches to master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,8 @@
   "require": {
     "cmb2/cmb2": "2.*",
     "composer/installers": "~1.0",
-    "greenpeace/planet4-master-theme" : "dev-planet-5843",
-    "greenpeace/planet4-plugin-gutenberg-blocks": "dev-planet-5843",
+    "greenpeace/planet4-master-theme" : "dev-master",
+    "greenpeace/planet4-plugin-gutenberg-blocks": "dev-master",
     "greenpeace/planet4-nginx-helper" : "2.2.*",
     "greenpeace/planet4-plugin-medialibrary" : "dev-master",
     "wikimedia/composer-merge-plugin": "1.4.1",


### PR DESCRIPTION
Reverts repositories branches to master.

This current configuration makes the docker-compose build fail during the assets creation because of some scss value missing. (failure which shouldn't happen either, it comes from 2 different installs of the repos during install, but I'll probably open a ticket for that)