### PR TITLE
PLANET-5519 Update Timber plugin to v1.18.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
     "wpackagist-plugin/google-apps-login": "3.4.3",
     "wpackagist-plugin/google-sitemap-generator": "4.*",
     "wpackagist-plugin/redirection": "4.*",
-    "wpackagist-plugin/timber-library": "1.16.0",
+    "wpackagist-plugin/timber-library": "1.18.*",
     "wpackagist-plugin/wordfence": "7.*",
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.1.*",


### PR DESCRIPTION
Ref. [JIRA 5519](https://jira.greenpeace.org/browse/PLANET-5519)

So far the minor version are mostly bug fixes, so i think its good to go with `1.18.*`.

Change log : https://wordpress.org/plugins/timber-library/#developers