### PR TITLE
PLANET-6015 Let test open panel itself

### DIFF
--- a/tests/_support/Step/Acceptance/Admin/CampaignGeneratorSteps.php
+++ b/tests/_support/Step/Acceptance/Admin/CampaignGeneratorSteps.php
@@ -35,6 +35,7 @@ class CampaignGeneratorSteps
 		$I = $this->tester;
 		$I->click( '//div[contains(@class, "editor-post-publish-panel__header-cancel-button")]/button[contains(text(), "Cancel")]' );
 		$I->click( '//button[@data-label="Campaign"]' );
+		$I->click( '//div[@id="p4_campaign_fields"]' );
 		$I->appendField( '#p4_campaign_name', $arg1 );
 	}
 


### PR DESCRIPTION
Opening the panel automatically doesn't work anymore after the changes. We will let the test do it itself for now.

Unfortunately our tests are not in the repository of the code they are testing, so this will have to be merged without confirmation (chicken and egg problem).