### PR TITLE
Fix editor selectors for wp5.6

### DIFF
--- a/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
+++ b/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
@@ -27,7 +27,7 @@ class GutenbergEditor
         $blockButton = (string) BlockSelector::BLOCK($blockName);
 
         $this->openBlockSelector();
-        $I->click((string) BlockSelector::SECTION($blockSection));
+        //$I->click((string) BlockSelector::SECTION($blockSection));
         $I->waitForElement($blockButton, 1);
         $I->click($blockButton);
     }

--- a/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
@@ -13,9 +13,9 @@ use MyCLabs\Enum\Enum;
  */
 class BlockSelector extends Enum
 {
-    private const MAIN_BUTTON = '.components-button.block-editor-inserter__toggle';
-    private const SECTION = '//button[contains(@class, "components-button")][text()="%s"]';
-    private const BLOCK = '//ul[contains(@class, "block-editor-block-types-list")]//button/span[text()="%s"]';
+    private const MAIN_BUTTON = '//button[contains(@aria-label, "Add block")]';
+    private const SECTION = '//div[contains(@class, "block-editor-block-types-list")][contains(@aria-label, "%s")]';
+    private const BLOCK = '//div[contains(@class, "block-editor-block-types-list")]//button/span[text()="%s"]';
 
     public static function SECTION(BlockSection $sectionName): self
     {

--- a/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
+++ b/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
@@ -93,9 +93,9 @@ class GutenbergEditorSteps
         $I = $this->tester;
 
         $this->iAddABlockFromSection('YouTube', 'Embeds');
-        $I->waitForElement('.has-selected-ui[aria-label="Block: YouTube"] input[type="url"]', 1);
-        $I->pressKey('.has-selected-ui[aria-label="Block: YouTube"] input[type="url"]', $link);
-        $I->click('.has-selected-ui[aria-label="Block: YouTube"] button[type="submit"]');
+        $I->waitForElement('.is-selected[aria-label="Block: Embed"] input[type="url"]', 1);
+        $I->pressKey('.is-selected[aria-label="Block: Embed"] input[type="url"]', $link);
+        $I->click('.is-selected[aria-label="Block: Embed"] button[type="submit"]');
     }
 
     /**


### PR DESCRIPTION
Fixes some selectors that changed with wp5.6.

## Fix

Some selectors were changed, to add blocks and use the Youtube block.
About the "section" functionality, the editor UI doesn't have an open/close section for blocks, so clicking on a section doesn't mean anything anymore. We could still check the section existence, but we can review this later after this quick fix.

## Test

In your local instance, 
```
> make php-shell
> git pull && git checkout fix/editor-feature-selectors
> cd tests
> vendor/bin/codecept -c ../codeception.yml run acceptance -vvv editor.feature
```
You need Selenium container running, which is not included by default in local development (available in full configuration, or copy/paste the `selenium` block in your docker-compose.yml file and `make down && make up` to install it).