### PR TITLE
PLANET-6085 Upgrade Wordpress to 5.6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "5.6.2"
+    "wp-version": "5.6.3"
   },
 
   "scripts": {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6085

---

This is a security update. The [post](https://wordpress.org/news/2021/04/wordpress-5-7-1-security-and-maintenance-release/) is about 5.7.1, but they issued a similar fix for all previous major versions.