### PR TITLE
PLANET-6020 Upgrade composer-merge-plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,8 @@ jobs:
       - run:
           name: Build containers
           working_directory: /home/circleci
-          command: make
+          command: |
+            GIT_REF=${CIRCLE_BRANCH} make
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "greenpeace/planet4-plugin-gutenberg-blocks": "dev-master",
     "greenpeace/planet4-nginx-helper" : "2.2.*",
     "greenpeace/planet4-plugin-medialibrary" : "v1.14",
-    "wikimedia/composer-merge-plugin": "1.4.1",
+    "wikimedia/composer-merge-plugin": "2.0.*",
     "wpackagist-plugin/akismet": "4.*",
     "wpackagist-plugin/cloudflare" : "3.8.6",
     "wpackagist-plugin/duplicate-post": "3.*",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6020

---

In preparation for upgrading to Composer 2.0.*. This looks safe enough to upgrade it already, and would help test the rest of the changes. We can then leave it untagged and test it on test/dev instances.

Also did one more commit to build containers for tests based on the current branch, instead of `main`.