### PR TITLE
PLANET-6145 Upgrade to Wordpres 5.6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "5.6.3"
+    "wp-version": "5.6.4"
   },
 
   "scripts": {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6145

---

This is a [security update](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/).