### PR TITLE
Fix tests errors on BlockSelector enum

### DIFF
--- a/tests/_support/Command/Selectors.php
+++ b/tests/_support/Command/Selectors.php
@@ -25,7 +25,6 @@ class Selectors extends Command implements CustomCommandInterface
      */
     private $selectorClasses = [
         GutenbergEditor::class,
-        BlockSelector::class,
         Sidebar::class,
     ];
 
@@ -60,7 +59,7 @@ class Selectors extends Command implements CustomCommandInterface
     /**
      * Displays a list of available selectors
      * Highlights variable parts
-     * 
+     *
      * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -76,7 +75,7 @@ class Selectors extends Command implements CustomCommandInterface
             ]);
             $table->addRows(array_map(
                 function ($key, $val) use ($class) { return [
-                    $this->constToMethod($key, $class), 
+                    $this->constToMethod($key, $class),
                     str_replace('%s', '<fg=yellow;options=bold>%s</>', $val)
                 ]; } ,
                 $class::keys(),
@@ -95,7 +94,7 @@ class Selectors extends Command implements CustomCommandInterface
 
     /**
      * Qualifies php-enum const as methods, check if they have specific parameters declaration
-     * 
+     *
      * @param string $const Constant name
      * @param string $class Class name
      *
@@ -110,7 +109,7 @@ class Selectors extends Command implements CustomCommandInterface
                     $ns = (new \ReflectionClass($class))->getNamespaceName();
                     return str_replace($ns . '\\', '', $param->getType())
                         . ' $' . $param->getName();
-                }, 
+                },
                 $rfl->getParameters()
             ));
 

--- a/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
+++ b/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
@@ -24,7 +24,7 @@ class GutenbergEditor
     public function addBlock(BlockSection $blockSection, BlockName $blockName): void
     {
         $I = $this->tester;
-        $blockButton = (string) BlockSelector::BLOCK($blockName);
+        $blockButton = BlockSelector::block($blockName);
 
         $this->openBlockSelector();
         //$I->click((string) BlockSelector::SECTION($blockSection));
@@ -35,6 +35,6 @@ class GutenbergEditor
     public function openBlockSelector(): void
     {
         $I = $this->tester;
-        $I->click((string) BlockSelector::MAIN_BUTTON());
+        $I->click(BlockSelector::MAIN_BUTTON);
     }
 }

--- a/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
@@ -4,39 +4,22 @@ declare(strict_types=1);
 
 namespace Selector\Admin\GutenbergEditor;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Selectors for the block selector
- * 
- * @method static BlockSelector MAIN_BUTTON()
  */
-class BlockSelector extends Enum
+class BlockSelector
 {
-    private const MAIN_BUTTON = '//button[contains(@aria-label, "Add block")]';
-    private const SECTION = '//div[contains(@class, "block-editor-block-types-list")][contains(@aria-label, "%s")]';
-    private const BLOCK = '//div[contains(@class, "block-editor-block-types-list")]//button/span[text()="%s"]';
+    public const MAIN_BUTTON = '//button[contains(@aria-label, "Add block")]';
+    public const SECTION = '//div[contains(@class, "block-editor-block-types-list")][contains(@aria-label, "%s")]';
+    public const BLOCK = '//div[contains(@class, "block-editor-block-types-list")]//button/span[text()="%s"]';
 
-    public static function SECTION(BlockSection $sectionName): self
+    public static function section(BlockSection $sectionName): string
     {
-        return new BlockSelector(sprintf(self::SECTION, (string) $sectionName));
+        return sprintf(self::SECTION, (string) $sectionName);
     }
 
-    public static function BLOCK(BlockName $blockName): self
+    public static function block(BlockName $blockName): string
     {
-        return new BlockSelector(sprintf(self::BLOCK, (string) $blockName));
-    }
-
-    /**
-     * Check if is valid enum value
-     * Overwrites Enum method to allow for parameters in const
-     *
-     * @param $value
-     * @see Enum::isValid()
-     * @return bool
-     */
-    public static function isValid($value): bool
-    {
-        return true;
+        return sprintf(self::BLOCK, (string) $blockName);
     }
 }


### PR DESCRIPTION
An update of the package [myclabs\enum](https://github.com/myclabs/php-enum/pull/97/files#diff-ee71af26064ea012953831df497c2297ea91606aa26bb133e73dc1b51deec2ccL46) triggered an error on some code doing an unconventional usage of the enum functionality.

## Fix 
Dropping the Enum class from BlockSelector, using only methods to return strings.

BlockSelector was also removed from the selectors [documentation function](https://github.com/greenpeace/planet4-base/pull/81), we'll have to find another way to document it.

## Test

I don't know if you have to be on a composer2 branch, I think just running composer update should have the same result: 
- assuming you haven't already, install tests `make test-install`
- go in `make php-shell`
- run `composer update`, it will update the enum package to a more recent version
- run `tests/vendor/bin/codecept run -vv acceptance editor.feature`