### PR TITLE
PLANET-6060 Install "Enable jQuery Migrate Helper" plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.1.*",
     "wpackagist-plugin/wp-sentry-integration":"3.*",
-    "wpackagist-plugin/wp-stateless": "2.*"
+    "wpackagist-plugin/wp-stateless": "2.*",
+    "wpackagist-plugin/enable-jquery-migrate-helper":"1.3.0"
   },
 
   "config": {


### PR DESCRIPTION
Ref: [PLANET-6060](https://jira.greenpeace.org/browse/PLANET-6060)

This plugin is a temporary solution for White TinyMce editor from wp_editor function on a meta box on WP 5.6+.
https://core.trac.wordpress.org/ticket/52050

**Testing steps:**
- The "Enable jQuery Migrate Helper" plugin is already installed on [sagardev](https://www-dev.greenpeace.org/sagardev/) test instance, disable the plugin and add/edit new page, the issue is reproducible there.
- Now active the plugin and test
eg. https://www-dev.greenpeace.org/sagardev/wp-admin/post-new.php?post_type=page