### PR TITLE
Pin Guzzle to below 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,8 @@
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.1.*",
     "wpackagist-plugin/wp-sentry-integration":"3.*",
-    "wpackagist-plugin/wp-stateless": "2.*"
+    "wpackagist-plugin/wp-stateless": "2.*",
+    "guzzlehttp/guzzle": "~6.0|~5.0|~4.0"
   },
 
   "config": {


### PR DESCRIPTION
wp-stateless is not compatible with Guzzle 7, even though they don't
declare this at all in their composer file.