### PR TITLE
PLANET-6359 Add Hubspot plugin to main repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
     "wpackagist-plugin/gdpr-comments":"1.0.2",
     "wpackagist-plugin/google-apps-login": "3.4.3",
     "wpackagist-plugin/google-sitemap-generator": "4.*",
+    "wpackagist-plugin/leadin": "8.*",
     "wpackagist-plugin/redirection": "4.*",
     "wpackagist-plugin/timber-library": "1.18.*",
     "wpackagist-plugin/wordfence": "7.*",


### PR DESCRIPTION
Since more and more NROs are start using the plugin, we can have this in base repo
to better handle its upgrades, and NROs that need it can activate it on their own.