### PR TITLE
PLANET-6307 Upgrade to latest Wordpress only on dev sites

### DIFF
--- a/tasks/post-deploy/06-update-users.sh
+++ b/tasks/post-deploy/06-update-users.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-wp user create dtovbein dtovbein@greenpeace.org --first_name="Dan" --last_name="Tovbein - P4 team" --role=administrator --porcelain || true
-wp user set-role dtovbein administrator
-wp user delete nhazim@greenpeace.org --reassign=1 --yes

--- a/tasks/post-deploy/06-wp58.sh
+++ b/tasks/post-deploy/06-wp58.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$APP_ENV" = "development" ]; then
+  wp core update --version=5.8.1
+  wp core update-db
+fi


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6307

---

This will allow both us and NROs to safely test Wordpress 5.8.x