### PR TITLE
PLANET-6484 Enable new navbar on non-customized websites

### DIFF
--- a/tasks/post-deploy/08-enable-new-navbar.sh
+++ b/tasks/post-deploy/08-enable-new-navbar.sh
@@ -1,7 +1,33 @@
 #!/bin/bash
 
-# Update new navbar design on dev sites
+# Update new navbar design on all dev sites
 if [ "$APP_ENV" = "development" ]; then
   wp option patch insert planet4_options new_design_country_selector 'on'
   wp option patch insert planet4_options new_design_navigation_bar 'on'
+  exit
 fi
+
+# All code below only runs on production/staging
+
+# Catch NROs on non-gp.org domains
+# ch, ummah, history, handbook, storytelling, gcefca
+if [[ -n "${APP_HOSTPATH}" ]]; then
+  echo "Excluded NRO: ${APP_HOSTNAME}"
+  exit
+fi
+
+# Other NRO websites with customized navbar
+excluded=(hongkong korea taiwan canada argentina japan belgium luxembourg denmark finland sweden norway)
+
+nro="${APP_HOSTPATH}"
+echo "NRO: ${nro}"
+
+for i in "${excluded[@]}"; do
+  if [ "$i" == "$nro" ]; then
+    echo "Excluded NRO"
+    exit
+  fi
+done
+
+wp option patch insert planet4_options new_design_country_selector 'on'
+wp option patch insert planet4_options new_design_navigation_bar 'on'

--- a/tasks/post-deploy/08-enable-new-navbar.sh
+++ b/tasks/post-deploy/08-enable-new-navbar.sh
@@ -17,7 +17,7 @@ if [[ -n "${APP_HOSTPATH}" ]]; then
 fi
 
 # Other NRO websites with customized navbar
-excluded=(hongkong korea taiwan canada argentina japan belgium luxembourg denmark finland sweden norway)
+excluded=(canada japan belgium brasil luxembourg denmark finland greenland norway sweden)
 
 nro="${APP_HOSTPATH}"
 echo "NRO: ${nro}"


### PR DESCRIPTION
Extended the post-deploy script to enable new navbar on non-customized websites, when everything is ready. So we don't have to do it manually.

In practice we exclude the ones listed in the `excluded` array, but also the ones with custom domain. It just happens that all of them have some sort of customization in their navbar template.