### PR TITLE
PLANET-6552 Wordpress upgrade to 5.8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "5.8.1"
+    "wp-version": "5.8.3"
   },
 
   "scripts": {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6552
Ref: https://wordpress.org/news/2022/01/wordpress-5-8-3-security-release/

---

This is a security upgrade, so we shouldn't expect anything affecting our functionality.

---

- To test locally, the easiest way is to get inside the php container and use `wp core update --version=5.8.3`
- Phobos instance is also upgraded to 5.8.3

