### PR TITLE
PLANET-6480 Delete css code from Customizer

### DIFF
--- a/tasks/post-deploy/05-custom-css.sh
+++ b/tasks/post-deploy/05-custom-css.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Deleting Custom CSS code..."
+for p in $(wp post list --post_type=custom_css --field=ID); do
+  wp post update "$p" --post_content=""
+done


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6480

---

CSS Customizer is stored as a post with its own post type (`custom_css`). This script just removes any content from there, right before we completely disable it. We need this because even if we disable the customizer menu any existing code will still be injected.

This happen as a for loop, since each theme has its own post for custom css and all NROs have two themes (master & child).