### PR TITLE
PLANET-6515 Update permalink structure

### DIFF
--- a/tasks/post-deploy/07-permalink-update.sh
+++ b/tasks/post-deploy/07-permalink-update.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# The new Action page, added a new rewrite rule which need to update existing permalink structure.
+echo "Update the permalink structure"
+wp rewrite flush


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-6515

As we are adding a new post type with rewrite rule, we need to update the permalink structure.

**Testing:**
- Checkout the `PLANET-6515-action-page-type` branch in master theme repo on local dev env.
- Enable the `Information Architecture >> Enable Action post type setting` feature flag
- Now add a new Action page from Admin side bar menu, save the page and go to frontend page, mostly it will show you the 404 page, because we introduce a new rewrite rule but the permalink structure is not updated for new rule
- Now connect to PHP container using `make php-shell` on local dev env, and run the post deploy script command here.
- Now refresh the new Action page on frontend, it should work fine.