### PR TITLE
Fix failing Youtube block test

### DIFF
--- a/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
+++ b/tests/_support/Page/Acceptance/Admin/GutenbergEditor.php
@@ -27,7 +27,11 @@ class GutenbergEditor
         $blockButton = BlockSelector::block($blockName);
 
         $this->openBlockSelector();
+        // Wait for panel to open
         $I->waitForElement('.block-editor-inserter__panel-header', 6);
+        // Wait for sections to load
+        $I->waitForElement($blockButton, 10);
+        // Scroll and click
         $I->scrollTo($blockButton);
         $I->click($blockButton);
     }

--- a/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
+++ b/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
@@ -37,7 +37,14 @@ class GutenbergEditorSteps
     public function iAddATitle(string $title): void
     {
         $I = $this->tester;
-        $I->fillField(EditorSelector::TITLE_FIELD(), $title);
+        try {
+          // Until 5.8.3
+          $I->fillField('#post-title-1', $title);
+        } catch (\Exception $e) {
+          // Since 5.9
+          $I->click(EditorSelector::TITLE_FIELD());
+          $I->type($title);
+        }
     }
 
     /**

--- a/tests/_support/Step/Acceptance/Admin/NavigationSteps.php
+++ b/tests/_support/Step/Acceptance/Admin/NavigationSteps.php
@@ -51,6 +51,7 @@ class NavigationSteps
     {
         $I = $this->tester;
         $I->amOnPage(Navigation::pageLink('Posts > Add New'));
+        $this->discardWelcomeGuide($I);
     }
 
     /**
@@ -69,5 +70,19 @@ class NavigationSteps
     {
       $I = $this->tester;
       $I->amOnPage(Navigation::pageLink('Campaigns > Add New'));
+      $this->discardWelcomeGuide($I);
+    }
+
+    protected function discardWelcomeGuide($I)
+    {
+        // Try closing welcome guide if it exists
+        try {
+          $I->click(
+            '//div[contains(@class, "edit-post-welcome-guide")]'
+            . '//button[contains(@aria-label, "Close dialog")]'
+          );
+        } catch (\Exception $e) {
+          // No welcome guide found
+        }
     }
 }


### PR DESCRIPTION
[CI report shows](https://30682-80401279-gh.circle-artifacts.com/0/planet4-docker-compose/artifacts/codeception/record_6217458f0ce95_editor.feature_Add_a_youtube_video_in_a_post/index.html) that the Youtube block button is not yet loaded when we try to click on it.

## Fixes 
- Wait for block list to load
  - This should give enough time for the button to become available
- Type h1 title instead of filling field
  - Issue seen locally on 5.9
- Close welcome guide if it exists
  - Issue seen locally on 5.9