### PR TITLE
PLANET-6630 Add GravityForms default settings and key

### DIFF
--- a/tasks/post-deploy/08-gravityforms.sh
+++ b/tasks/post-deploy/08-gravityforms.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Set GF settings..."
+wp option update rg_gforms_key "${GF_LICENSE}"
+wp option add rg_gforms_enable_akismet 1 || true
+wp option add gform_enable_noconflict 1 || true
+wp option add gform_enable_background_updates 0 || true
+wp option add rg_gforms_enable_html5 1 || true
+wp option patch insert stateless-modules gravity-form true || wp option add stateless-modules '{"gravity-form": "true"}' --format=json


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6630

---

### Testing

1. Install the plugin
```
wp plugin install https://storage.googleapis.com/planet4-3rdparty-plugins/gravityforms_2.5.16.3.zip
```
2. Set a custom License key for testing
```
export GF_LICENSE="randomstring"
```
3. Run this script (or just each individual line).
4. Activate the plugin from the admin panel
5. Go to its settings. It should already have the license key (of course it will complain that it's not valid) set and the config option set in this script.