### PR TITLE
PLANET-6583 Upgrade to Wordpress 5.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "5.8.4"
+    "wp-version": "5.9.2"
   },
 
   "scripts": {

--- a/development.json
+++ b/development.json
@@ -1,8 +1,5 @@
 {
   "require": {
     "greenpeace/planet4-master-theme": "dev-tag-page-redirection-6619"
-  },
-  "extra": {
-    "wp-version": "5.9.2"
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6583

---

Testing this so far hasn't reveal anything new. Tested also on dev site with WPML.

### Testing

To test this locally, on a new docker-composer environment I just changed [GIT_REF](https://github.com/greenpeace/planet4-docker-compose/blob/master/docker-compose.yml#L67). On existing environment `wp-cli` should work.