### PR TITLE
Sleep for a short amount of time between releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ job_definitions:
               for i in "${sites[@]}"
               do
                 trigger-build.sh git@github.com:greenpeace/planet4-$i.git << parameters.pipeline >>
+                sleep 30
               done
       - when:
           condition:


### PR DESCRIPTION
For now added on all sites as the code doesn't easily allow targetting only the dev sites.

This should offset the start time of deployments, making it much less likely for an expensive task to be executed for many sites at the same time. Our CircleCI plan changed in a way that we now have a much higher concurrency limit. Before only 7 jobs would start at a time, now it's likely over 20.

Dev cluster has lower resources and can't take that many deployments at the same time.

30 seconds * 60 sites = 1800 seconds, or half an hour. (rounded the numbers a bit as the actual times are not always the same anyway)