### PR TITLE
Bump Cloudflare plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
     "greenpeace/planet4-plugin-medialibrary" : "v1.14",
     "wikimedia/composer-merge-plugin": "2.0.*",
     "wpackagist-plugin/akismet": "4.*",
-    "wpackagist-plugin/cloudflare" : "4.7.0",
+    "wpackagist-plugin/cloudflare" : "4.8.3",
     "wpackagist-plugin/duplicate-post": "4.1.*",
     "wpackagist-plugin/elasticpress":"3.5.*",
     "wpackagist-plugin/google-apps-login": "3.4.4",


### PR DESCRIPTION
This version prevents sending a purge request to HTTP URLs we don't use.
It probably cuts the amount of purge requests in half, so a lot less chance to hit a rate limit.

See [changes compared to previous version](https://github.com/cloudflare/Cloudflare-WordPress/compare/v4.7.0...v4.8.3#diff-2a70cd376329114790256e804423dac696b9d4d13a102a100db7c85a3c6e9049R185-R189). (click "Files changed" tab to focus the right lines)

https://github.com/cloudflare/Cloudflare-WordPress/blob/a2a56c4523165969ae3b76b40374d027f52126ea/src/WordPress/Hooks.php#L185-L189

We should be fine even if page rules are not available in the plugin.

It removes all HTTP URLs when no rule disabling HTTPS was found.