### PR TITLE
Upgrade to Wordpress 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "5.9.3"
+    "wp-version": "6.0"
   },
 
   "scripts": {

--- a/development.json
+++ b/development.json
@@ -1,8 +1,5 @@
 {
   "require": {
     "wpackagist-plugin/wp-sentry-integration":"4.*"
-  },
-  "extra": {
-    "wp-version": "6.0"
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6811

---

Besides the duotones issue (merged already) didn't notice any other breaking change, either locally or in dev sites.