### PR TITLE
Upgrade WPML to 4.5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "name": "plugins/sitepress-multilingual-cms",
         "version": "4.4.10",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.4.10.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.5.8.zip",
           "type": "zip"
         }
       }
@@ -46,7 +46,7 @@
         "name": "plugins/wpml-string-translation",
         "version": "3.1.8",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-string-translation.3.1.8.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-string-translation.3.2.1.zip",
           "type": "zip"
         }
       }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6833

### Testing

```
git clone git@github.com:greenpeace/planet4-docker-compose.git pdc-wpml
cd pdc-wpml
GIT_REF=planet-6833/wpml make dev
```

Check a WPML site, by adding these two lines to `Makefile.include`
```
NRO_NAME := switzerland
NRO_DB_VERSION ?= latest
```

And then run:
```
make nro-enable
```