### PR TITLE
PLANET-6810: Update Sentry plugin to 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
     "wpackagist-plugin/wordfence": "7.*",
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.2.*",
-    "wpackagist-plugin/wp-sentry-integration":"3.*",
+    "wpackagist-plugin/wp-sentry-integration":"5.*",
     "wpackagist-plugin/wp-stateless":"3.2.*",
     "guzzlehttp/guzzle": "~6.0|~5.0|~4.0"
   },

--- a/development.json
+++ b/development.json
@@ -1,6 +1,5 @@
 {
   "require": {
-    "wpackagist-plugin/wp-sentry-integration":"4.*",
     "wpackagist-plugin/timber-library": "1.20.*"
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6810

The functions we use [have not seen a significant signature change](https://github.com/getsentry/sentry-php/compare/2.5.2...3.6.1#diff-fe65dcdace9cc44252b537bee79dd574edd1bccf6cee646cc860006a6ec50e8b) between those versions
- [`\Sentry\withScope`](https://github.com/getsentry/sentry-php/blob/5b8f2934b0b20bb01da11c76985ceb5bd6c6af91/src/functions.php#L104)
- [`\Sentry\captureMessage`](https://github.com/getsentry/sentry-php/blob/5b8f2934b0b20bb01da11c76985ceb5bd6c6af91/src/functions.php#L30)
- [`\Sentry\captureException`](https://github.com/getsentry/sentry-php/blob/5b8f2934b0b20bb01da11c76985ceb5bd6c6af91/src/functions.php#L41)

Breaking releases of the plugin
- [4.0.0](https://github.com/stayallive/wp-sentry/releases/tag/v4.0.0)
- [5.0.0](https://github.com/stayallive/wp-sentry/releases/tag/v5.0.0)

Event logged with plugin version 5.1:
https://sentry.greenpeace.org/organizations/greenpeace-org/issues/690/events/42c8eec223d14783a13d67786a20490d/
https://sentry.greenpeace.org/organizations/greenpeace-org/issues/673/events/373739b7618a491ea2a0974e94f340e0/?project=2

## Test

Locally, run
`docker-compose exec php-fpm wp plugin update wp-sentry-integration`
This will update the plugin to the last version. You can then manually add some logging functions `\Sentry\captureMessage('Test message')` to the function.php file of the master theme for example.