### PR TITLE
PLANET-6850 Add allow-plugns config to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,11 @@
 
   "config": {
     "secure-http": false,
-    "github-protocols": ["https"]
+    "github-protocols": ["https"],
+    "allow-plugins": {
+      "composer/installers": true,
+      "wikimedia/composer-merge-plugin": true
+    }
   },
 
   "extra": {

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,27 +1,28 @@
 {
-	"name": "greenpeace/planet4-base-tests",
-	"description": "Tests for the Greenpeace Planet4 NRO application",
-	"license": "GPL-3.0-or-later",
-	"repositories": [
-		{
-			"type": "composer",
-			"url": "https://packagist.org"
-		}
-	],
-	"require": {
-		"codeception/module-asserts": "^1.2.1",
-		"codeception/module-db": "^1.0.1",
-		"codeception/module-webdriver": "^1.1.0",
-		"codeception/module-cli": "^1.0.2"
-	},
-	"config": {
-		"secure-http": false,
-		"github-protocols": ["https"]
-	},
-	"require-dev": {
-		"codeception/c3": "^2.4.1",
-		"lucatume/wp-browser": ">=3.0.10",
-		"myclabs/php-enum": "^1.7",
-		"wp-cli/wp-cli-bundle": "^2.5"
-	}
+  "name": "greenpeace/planet4-base-tests",
+  "description": "Tests for the Greenpeace Planet4 NRO application",
+  "license": "GPL-3.0-or-later",
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packagist.org"
+    }
+  ],
+  "require": {
+    "codeception/module-asserts": "^1.2.1",
+    "codeception/module-db": "^1.0.1",
+    "codeception/module-webdriver": "^1.1.0",
+    "codeception/module-cli": "^1.0.2"
+  },
+  "config": {
+    "allow-plugins": {
+      "codeception/c3": true
+    }
+  },
+  "require-dev": {
+    "codeception/c3": "^2.4.1",
+    "lucatume/wp-browser": ">=3.0.10",
+    "myclabs/php-enum": "^1.7",
+    "wp-cli/wp-cli-bundle": "^2.5"
+  }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6850
Ref: https://getcomposer.org/doc/06-config.md#allow-plugins

---

This is required by newer composer versions.

Main PR: https://github.com/greenpeace/planet4-docker/pull/101

---

Hide whitespace for easier reviewing

![whitespace](https://user-images.githubusercontent.com/939357/179231966-820e1eef-b1ce-4f1f-98c0-b61033a10c74.png)
