### PR TITLE
Remove code coverage from acceptance test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,10 @@ job_definitions:
       - run:
           name: Run tests
           command: |
-            make -C planet4-docker-compose test-codeception
+            cd planet4-docker-compose
+            docker-compose exec php-fpm rsync -a --delete public/wp-content/themes/planet4-master-theme/tests/acceptance/ public/wp-content/plugins/planet4-plugin-gutenberg-blocks/tests/acceptance/ tests/acceptance/
+            docker-compose exec php-fpm rsync -a --delete public/wp-content/themes/planet4-master-theme/tests/data/ tests/_data/
+            docker-compose exec php-fpm tests/vendor/bin/codecept run acceptance --no-redirect --xml=junit.xml --html
       - run:
           name: Extract test artifacts
           when: always

--- a/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
+++ b/tests/_support/Step/Acceptance/Admin/GutenbergEditorSteps.php
@@ -143,7 +143,7 @@ class GutenbergEditorSteps
     {
         // @todo: check message content
         $I = $this->tester;
-        $I->waitForElement((string) EditorSelector::VALIDATION_MESSAGE(), 10);
+        $I->waitForElement((string) EditorSelector::VALIDATION_MESSAGE(), 30);
     }
 
     /**


### PR DESCRIPTION
- Remove code coverage from acceptance test to limit test failure unrelated to test
- Wait longer for campaign validation