### PR TITLE
PLANET-6914 Upgrade to WordPress 6.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -202,7 +202,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "6.0.3"
+    "wp-version": "6.1.1"
   },
 
   "scripts": {

--- a/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
+++ b/tests/_support/Selector/Admin/GutenbergEditor/BlockSelector.php
@@ -11,7 +11,7 @@ class BlockSelector
 {
     public const MAIN_BUTTON = '//button[contains(@aria-label, "Toggle block inserter")]';
     public const SECTION = '//div[contains(@class, "block-editor-block-types-list")][contains(@aria-label, "%s")]';
-    public const BLOCK = '//div[contains(@class, "block-editor-block-types-list")]//button/span[text()="%s"]';
+    public const BLOCK = '//div[contains(@class, "block-editor-block-types-list")]//button//span[text()="%s"]';
 
     public static function section(BlockSection $sectionName): string
     {


### PR DESCRIPTION
### Description

See [PLANET-6914](https://jira.greenpeace.org/browse/PLANET-6914)
Some small fixes are needed in master-theme before this upgrade, see [corresponding PR](https://github.com/greenpeace/planet4-master-theme/pull/1842)