### PR TITLE
PLANET-7111: Upgrade Wordpress to 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -192,7 +192,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "6.1.1"
+    "wp-version": "6.2"
   },
 
   "scripts": {


### PR DESCRIPTION
Ref: [PLANET-7111](https://jira.greenpeace.org/browse/PLANET-7111)

## Description
Upgrade to Wordpress 6.2

## Related PR(s)
- https://github.com/greenpeace/planet4-develop/pull/11

**Other related PRs (not a blockers, but experiments)**
- https://github.com/greenpeace/planet4-master-theme/pull/1982
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1033

## Relevant information
- [Wordpress's latest releases](https://wordpress.org/news/category/releases/)
- [Wordpress 6.2 field guide](https://make.wordpress.org/core/2023/03/09/wordpress-6-2-field-guide/)