### PR TITLE
PLANET-6235: Update ElasticPress to 4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,7 +153,7 @@
     "wpackagist-plugin/akismet": "5.*",
     "wpackagist-plugin/cloudflare" : "4.*",
     "wpackagist-plugin/duplicate-post": "4.*",
-    "wpackagist-plugin/elasticpress":"3.5.*",
+    "wpackagist-plugin/elasticpress":"4.5.*",
     "wpackagist-plugin/google-apps-login": "3.4.6",
     "plugins/gravityforms": "*",
     "plugins/gravityformsquiz": "*",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6235

Changelog: https://github.com/10up/ElasticPress/blob/develop/CHANGELOG.md (from [3.5.6](https://github.com/10up/ElasticPress/blob/develop/CHANGELOG.md#356---2021-03-18))


Some commands have changed. We only use indexation, and the old command is deprecated but not removed so we can apply those changes after update:

Old Command | New Command
-- | --
wp elasticpress index | wp elasticpress sync
wp elasticpress get-cluster-indexes | wp elasticpress get-cluster-indices
wp elasticpress get-indexes | wp elasticpress get-indices
wp elasticpress clear-index | wp elasticpress clear-sync
wp elasticpress get-indexing-status | wp elasticpress get-ongoing-sync-status
wp elasticpress get-last-cli-index | wp elasticpress get-last-cli-sync
wp elasticpress stop-indexing | wp elasticpress stop-sync

Some filters have changed, but we don't use any of those:


Old Filter | New Filter
-- | --
ep_formatted_args_query | ep_post_formatted_args_query
ep_match_phrase_boost | ep_post_match_phrase_boost
ep_match_boost | ep_post_match_boost
ep_fuzziness_arg | ep_post_fuzziness_arg
ep_match_fuzziness | ep_post_match_fuzziness
ep_match_cross_fields_boost | ep_post_match_cross_fields_boost


Our current installation of Elasticpress With WPML doesn't allow for language specific search. We should open a ticket to try the plugin dedicated to this https://wpml.org/documentation/plugins-compatibility/using-elasticpress-on-your-multilingual-site/ (using the [master branch](https://github.com/OnTheGoSystems/wpml-elasticpress) instead of the release).
