### PR TITLE
PLANET-7211: Update for compatibility with PHP 8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ job_definitions:
             CI:
             PW_RETRIES: 1
             PW_WORKERS: 3
+            PW_TEST_HTML_REPORT_OPEN: "never"
           command: |
             echo -e "\n# Planet4 local development environment\n127.0.0.1\twww.planet4.test" | sudo tee -a /etc/hosts;
             nvm use

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
       "type": "package",
       "package": {
         "name": "plugins/sitepress-multilingual-cms",
-        "version": "4.5.12",
+        "version": "4.6.6",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.5.12.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.6.6.zip",
           "type": "zip"
         }
       }
@@ -155,7 +155,7 @@
   "require": {
     "cmb2/cmb2": "2.*",
     "composer/installers": "~1.0",
-    "google/apiclient": "^2.12",
+    "google/apiclient": "^2.15",
     "greenpeace/planet4-master-theme" : "dev-main",
     "greenpeace/planet4-plugin-gutenberg-blocks": "dev-main",
     "greenpeace/planet4-nginx-helper" : "2.2.*",
@@ -175,8 +175,7 @@
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.4.*",
     "wpackagist-plugin/wp-sentry-integration":"6.*",
-    "wpackagist-plugin/wp-stateless":"3.2.2",
-    "guzzlehttp/guzzle": "~6.0|~5.0|~4.0"
+    "wpackagist-plugin/wp-stateless":"3.2.2"
   },
 
   "config": {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7211

This removes errors and deprecation messages coming from those plugins on PHP8.1.

- [7.4 test](https://app.circleci.com/pipelines/github/greenpeace/planet4-develop?branch=test%2Fbase-php81&filter=all)
- [8.1 test](https://app.circleci.com/pipelines/github/greenpeace/planet4-develop?branch=feature%2Fphp81&filter=all)

## WPML 4.5.12 -> 4.6.6
### [Changelogs](https://wpml.org/download/wpml-multilingual-cms/?section=changelog)
- 4.5.13 https://wpml.org/changelog/2022/10/wpml-4-5-12-updates-for-wordpress-6-1/
  - Update for WP 6.1 compatibility
- 4.5.14 https://wpml.org/changelog/2022/11/wpml-4-5-14-security-improvements/
  - Security release
- 4.6 https://wpml.org/changelog/2023/03/wpml-4-6-bulk-auto-translation-language-switcher-block-translation-mode-improvements/
  - Language switcher block for Gutenberg
- 4.6.1 https://wpml.org/changelog/2023/03/wpml-4-6-1-important-security-update/
  - Security release
- 4.6.3 https://wpml.org/changelog/2023/03/wpml-4-6-3-getting-ready-for-wordpress-6-2/
  - Fixes for PHP8 and 8.1
- 4.6.4 https://wpml.org/changelog/2023/06/wpml-4-6-4-wcml-5-2-0-elevated-user-experience-and-performance/
  - Fixes for PHP8.1
- 4.6.5 https://wpml.org/changelog/2023/08/wpml-4-6-5-compatibility-with-wordpress-6-3/
  - Compatibility for WP 6.3
- 4.6.6 https://wpml.org/changelog/2023/08/wpml-4-6-6-patchfix-release/

## Google API Client 2.12 -> 2.15.1
### Changelogs
- https://github.com/googleapis/google-api-php-client/blob/main/CHANGELOG.md
- [Fix for PHP8.1](https://github.com/googleapis/google-api-php-client/pull/2259)
- [Support for PHP8.2](https://github.com/googleapis/google-api-php-client/pull/2350)