### PR TITLE
Fix guzzle/wp-stateless psr versions mixup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -175,7 +175,8 @@
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.4.*",
     "wpackagist-plugin/wp-sentry-integration":"6.*",
-    "wpackagist-plugin/wp-stateless":"3.2.2"
+    "wpackagist-plugin/wp-stateless":"3.2.2",
+    "psr/http-message": "1.1"
   },
 
   "config": {


### PR DESCRIPTION
Ref: https://sentry.greenpeace.org/organizations/greenpeace-org/issues/141/

> Compile Error: Declaration of Google\Cloud\Storage\WriteStream::close() must be compatible with Psr\Http\Message\StreamInterface::close(): void

Removing Guzzle declaration probably brought back this issue https://github.com/greenpeace/planet4-base/pull/142
Guzzle has [compatible declarations](https://github.com/guzzle/psr7/blob/2.6/composer.json#L55) for different versions of PSR, so we can fix this version to still be compatible with wp-stateless [embedded GoogleCloud library](https://github.com/udx/wp-stateless/blob/3.2.2/lib/Google/vendor/google/cloud-storage/src/WriteStream.php#L63) implementation.