### PR TITLE
Downgrade google auth lib to version compatible with stateless

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,8 @@
   "require": {
     "cmb2/cmb2": "2.*",
     "composer/installers": "~1.0",
-    "google/apiclient": "^2.15",
+    "google/apiclient": "2.14.0",
+    "google/auth": "1.10.0",
     "greenpeace/planet4-master-theme" : "dev-main",
     "greenpeace/planet4-plugin-gutenberg-blocks": "dev-main",
     "greenpeace/planet4-nginx-helper" : "2.2.*",


### PR DESCRIPTION
Because of some issues with wp-stateless including vendor lib and import path, we have to keep our google/apiclient and google/auth packages versions to the same state they are in wp-stateless.

The Error stacktrace shows that the google lib dependency included in wp-stateless takes over the import path of the google/apiclient lib we include with composer for our GoogleDocsClient/AnalyticsValues classes

```
Error: Call to undefined method Google\Auth\FetchAuthTokenCache::getFetcher()
#31 /app/source/vendor/google/auth/src/Middleware/AuthTokenMiddleware.php(131): Google\Auth\Middleware\AuthTokenMiddleware::addAuthHeaders
#30 /app/source/vendor/google/auth/src/Middleware/AuthTokenMiddleware.php(108): Google\Auth\Middleware\AuthTokenMiddleware::Google\Auth\Middleware\{closure}
#29 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php(35): GuzzleHttp\PrepareBodyMiddleware::__invoke
#28 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/Middleware.php(31): GuzzleHttp\Middleware::GuzzleHttp\{closure}
#27 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php(71): GuzzleHttp\RedirectMiddleware::__invoke
#26 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/Middleware.php(61): GuzzleHttp\Middleware::GuzzleHttp\{closure}
#25 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/HandlerStack.php(75): GuzzleHttp\HandlerStack::__invoke
#24 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/Client.php(331): GuzzleHttp\Client::transfer
#23 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/Client.php(107): GuzzleHttp\Client::sendAsync
#22 /wp-content/plugins/wp-stateless/lib/Google/vendor/guzzlehttp/guzzle/src/Client.php(123): GuzzleHttp\Client::send
#21 /wp-content/plugins/wp-stateless/lib/Google/vendor/google/auth/src/HttpHandler/Guzzle6HttpHandler.php(47): Google\Auth\HttpHandler\Guzzle6HttpHandler::__invoke
#20 /wp-content/plugins/wp-stateless/lib/Google/src/Http/REST.php(82): Google\Http\REST::doExecute
#19 [internal](0): call_user_func_array
#18 /wp-content/plugins/wp-stateless/lib/Google/src/Task/Runner.php(187): Google\Task\Runner::run
#17 /wp-content/plugins/wp-stateless/lib/Google/src/Http/REST.php(65): Google\Http\REST::execute
#16 /wp-content/plugins/wp-stateless/lib/Google/src/Client.php(920): Google\Client::execute
#15 /wp-content/plugins/wp-stateless/lib/Google/src/Service/Resource.php(238): Google\Service\Resource::call
#14 /app/source/vendor/google/apiclient-services/src/Sheets/Resource/SpreadsheetsValues.php(241): Google\Service\Sheets\Resource\SpreadsheetsValues::get
#13 /app/source/vendor/themes/planet4-master-theme/src/GoogleDocsClient.php(71): P4\MasterTheme\GoogleDocsClient::get_sheet
#12 /app/source/vendor/themes/planet4-master-theme/src/AnalyticsValues.php(209): P4\MasterTheme\AnalyticsValues::using_google
#11 /app/source/vendor/themes/planet4-master-theme/src/AnalyticsValues.php(176): P4\MasterTheme\AnalyticsValues::from_cache_or_api_or_hardcoded
#10 /app/source/vendor/themes/planet4-master-theme/src/MasterSite.php(1683): P4\MasterTheme\MasterSite::save_global_project_id
```

Here it clearly goes:
- P4\MasterTheme\GoogleDocsClient
- vendor/google/apiclient-services
- /wp-content/plugins/wp-stateless/lib/Google/src/Service

This would imply there is a conflict on import path. If google/apiclient and wp-stateless/lib/Google versions diverge sufficiently, it leads to mismatch in classes and methods signatures.

- A [first fix](https://github.com/greenpeace/planet4-master-theme/pull/2166) was to capture those error, to avoid blocking other processes
- This fix makes both libs match versions
- A future fix could be to not use google/apiclient and make a small implementation for our limited usage