### PR TITLE
Stop any ongoing elastic search sync

### DIFF
--- a/tasks/post-deploy/10-es-sync.sh
+++ b/tasks/post-deploy/10-es-sync.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "Delete existing Elasticsearch index and recreate it..."
-wp elasticpress sync --setup --yes
+wp elasticpress sync --setup --yes --force


### PR DESCRIPTION
This PR will hopefully avoid below error -

> Delete existing Elasticsearch index and recreate it...
Error: An index is already occurring. Try again later.
command terminated with exit code 1
make: *** Makefile:272: post-deploy Error 1
Exited with code exit status 2

`wp elasticpress sync --setup --yes --force`
[--force]: Stop any ongoing sync
Ref. https://10up.github.io/ElasticPress/tutorial-wp-cli.html