### PR TITLE
PLANET-7192 Remove Sync ES index command

### DIFF
--- a/tasks/post-deploy/10-es-sync.sh
+++ b/tasks/post-deploy/10-es-sync.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Delete existing Elasticsearch index and recreate it..."
-wp elasticpress sync --setup --yes


### PR DESCRIPTION
After Elasticpress plugin and elasticsearch cluster upgrade, we have sync the indexes. now we don't need to sync it on each post deploy operation, hence removing the `tasks/post-deploy/10-es-sync.sh` script.