### PR TITLE
Fix monolog version to compat with current psr-log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,8 @@
     "wpackagist-plugin/wp-redis": "1.4.*",
     "wpackagist-plugin/wp-sentry-integration":"6.*",
     "wpackagist-plugin/wp-stateless":"3.2.2",
-    "psr/http-message": "1.1"
+    "psr/http-message": "1.1",
+    "monolog/monolog": "^2.9"
   },
 
   "config": {


### PR DESCRIPTION
Ref: https://sentry.greenpeace.org/organizations/greenpeace-org/issues/291/?query=is%3Aunresolved+runtime%3A%22php+8.1.2%22&referrer=issue-stream&stream_index=0

Fixes monolog/monolog version to be compatible with current psr-log interface

[Deployed](https://github.com/greenpeace/planet4-test-pandora/commit/7d1f813fdbc9ffbb4b4b3076fb6be47ba1f15c8f) on [Pandora](https://www-dev.greenpeace.org/test-pandora/)