### PR TITLE
PLANET-7388: Update packages post PHP8 deployment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,7 @@
   "require": {
     "cmb2/cmb2": "2.*",
     "composer/installers": "~1.0",
-    "google/apiclient": "^2.15",
+    "google/apiclient": "2.15.3",
     "greenpeace/planet4-master-theme" : "dev-main",
     "greenpeace/planet4-plugin-gutenberg-blocks": "dev-main",
     "greenpeace/planet4-nginx-helper" : "2.2.*",
@@ -171,12 +171,12 @@
     "plugins/gravityformsquiz": "*",
     "wpackagist-plugin/post-type-switcher": "3.2.2",
     "wpackagist-plugin/redirection": "5.*",
-    "wpackagist-plugin/timber-library": "1.22.*",
+    "wpackagist-plugin/timber-library": "1.23.*",
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.4.*",
-    "wpackagist-plugin/wp-sentry-integration":"6.*",
-    "wpackagist-plugin/wp-stateless":"3.2.2",
-    "psr/http-message": "1.1",
+    "wpackagist-plugin/wp-sentry-integration":"7.*",
+    "wpackagist-plugin/wp-stateless":"3.4.0",
+    "psr/log": "1.*",
     "monolog/monolog": "^2.9"
   },
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7388
Requires: https://github.com/greenpeace/planet4-master-theme/pull/2201
Related: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1185

## Updated
- Update wp-stateless to 3.4.0
- Update timber to 1.23.0
  - this version still produces [some deprecations](https://github.com/timber/timber/issues/2768#issuecomment-1598294883), we will have to move to 2.0 to fix all those
- Update sentry integration to 7.4.0

## Test
- Tested on local development [CI](https://app.circleci.com/pipelines/github/greenpeace/planet4-develop/542) | [branch](https://github.com/greenpeace/planet4-develop/compare/main...update/post-php8)
- Deployed on test instance Venus [CI](https://app.circleci.com/pipelines/github/greenpeace/planet4-test-venus/585) | [tests](https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/9216/workflows/d3a7598d-192a-47a2-b128-1ef602f42e56/jobs/68545) | [branch](https://github.com/greenpeace/planet4-test-venus/commit/b2f08161dc57d29d31976dfadfeacc49507899bc) 
