### PR TITLE
Update post-type-switcher plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,7 @@
     "plugins/gravityforms": "*",
     "plugins/gravityformshubspot": "*",
     "plugins/gravityformsquiz": "*",
-    "wpackagist-plugin/post-type-switcher": "3.2.2",
+    "wpackagist-plugin/post-type-switcher": "3.3.0",
     "wpackagist-plugin/redirection": "5.*",
     "wpackagist-plugin/timber-library": "1.23.*",
     "wpackagist-plugin/wordpress-importer": "0.*",


### PR DESCRIPTION
Update [post-type-switcher](https://wordpress.org/plugins/post-type-switcher/) version, currently used version 3.2.2 disappeared from repo (cf [failed CI job](https://app.circleci.com/pipelines/github/greenpeace/planet4-luxembourg/2659/workflows/8e586c13-16da-46b1-b0d6-49e96698c587/jobs/7592/parallel-runs/0/steps/0-111)).
- [3.2.2 - 3.3.0 diff](https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&new=3043096%40post-type-switcher%2Ftrunk&old=3021527%40post-type-switcher%2Ftrunk&sfp_email=&sfph_mail=)