### PR TITLE
PLANET-7390: Update Timber to a composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -171,13 +171,14 @@
     "plugins/gravityformsquiz": "*",
     "wpackagist-plugin/post-type-switcher": "3.3.0",
     "wpackagist-plugin/redirection": "5.*",
-    "wpackagist-plugin/timber-library": "1.23.*",
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.4.*",
     "wpackagist-plugin/wp-sentry-integration":"7.*",
     "wpackagist-plugin/wp-stateless":"3.4.0",
     "psr/log": "1.*",
-    "monolog/monolog": "^2.9"
+    "monolog/monolog": "^2.9",
+    "wpackagist-plugin/timber-library": "1.23.*",
+    "timber/timber": "1.24.0"
   },
 
   "config": {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7390
Requires: https://github.com/greenpeace/planet4-master-theme/pull/2228
Requires: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1195

Cf. https://timber.github.io/docs/v1/getting-started/switch-to-composer/#4.-install-the-latest-1.x-version-of-timber-via-composer

Add Timber as a composer package during transition
First step to update Timber to 2.0

## Test
- _planet4-develop_ branch for tests: `update/timber-composer-7390`
- fully deployed on [test-leda](https://www-dev.greenpeace.org/test-leda/)