### PR TITLE
Update to Timber 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -166,9 +166,7 @@
     "wpackagist-plugin/wp-stateless":"4.1.3",
     "wpackagist-plugin/wp-stateless-gravity-forms-addon":"0.0.2",
     "psr/log": "1.*",
-    "monolog/monolog": "^2.9",
-    "wpackagist-plugin/timber-library": "1.23.*",
-    "timber/timber": "1.24.0"
+    "monolog/monolog": "^2.9"
   },
 
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -166,7 +166,8 @@
     "wpackagist-plugin/wp-stateless":"4.1.3",
     "wpackagist-plugin/wp-stateless-gravity-forms-addon":"0.0.2",
     "psr/log": "1.*",
-    "monolog/monolog": "^2.9"
+    "monolog/monolog": "^2.9",
+    "timber/timber": "2.1.*"
   },
 
   "config": {

--- a/development.json
+++ b/development.json
@@ -1,7 +1,6 @@
 {
   "require": {
     "timber/timber": "2.1.*",
-    "greenpeace/planet4-master-theme": "dev-feat/timber-2",
-    "greenpeace/planet4-plugin-gutenberg-blocks": "dev-feat/timber-2"
+    "greenpeace/planet4-master-theme": "dev-feat/timber-2"
   }
 }

--- a/development.json
+++ b/development.json
@@ -1,0 +1,7 @@
+{
+  "require": {
+    "timber/timber": "2.1.*",
+    "greenpeace/planet4-master-theme": "dev-feat/timber-2",
+    "greenpeace/planet4-plugin-gutenberg-blocks": "dev-feat/timber-2"
+  }
+}

--- a/development.json
+++ b/development.json
@@ -1,6 +1,0 @@
-{
-  "require": {
-    "timber/timber": "2.1.*",
-    "greenpeace/planet4-master-theme": "dev-feat/timber-2"
-  }
-}

--- a/production.json
+++ b/production.json
@@ -1,5 +1,7 @@
 {
   "require": {
-    "greenpeace/planet4-master-theme": "v1.346.0"
+    "greenpeace/planet4-master-theme": "v1.346.0",
+    "wpackagist-plugin/timber-library": "1.23.*",
+    "timber/timber": "1.24.0"
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7390
Requires: https://github.com/greenpeace/planet4-master-theme/pull/2280
Requires: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1208
Doc: [Timber upgrade guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/)

NROs with templates modifications (either php or twig) should be locked on previous version until changes are made and tested.

A configured dev env is available on branch [planet4-develop@feat/timber-2](https://github.com/greenpeace/planet4-develop/tree/feat/timber-2)