### PR TITLE
PLANET-7494: Update to WordPress 6.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -205,7 +205,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "6.4.3"
+    "wp-version": "6.5.3"
   },
 
   "scripts": {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7494

# Description
Upgrade to the LTS WordPress version. Currently is the `6.5.3` which has been released on May, 7.
https://wordpress.org/news/2024/05/wordpress-6-5-3-maintenance-release/

### Related PRs that might be merged in parallel
- [planet4-develop#41](https://github.com/greenpeace/planet4-develop/pull/41)
- [planet4-master-theme#2281](https://github.com/greenpeace/planet4-master-theme/pull/2281)
- https://github.com/greenpeace/planet4-master-theme/pull/2289
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1209

### Related Tickets to follow up
- [PLANET-7530](https://jira.greenpeace.org/browse/PLANET-7530)
- [PLANET-7517](https://jira.greenpeace.org/browse/PLANET-7517) (not related to WP6.5)

Also updated the [Experimentation Day future ideas document](https://docs.google.com/document/d/1qZfQZCCtoA9lyo4Uyof3l0dYXbqtrru5KznyEHMuLOg/edit).

## Testing
#### Locally
Run `npx wp-env run cli wp core update --version=6.5.3` on your terminal OR playing around the [mars instance](https://github.com/greenpeace/planet4-test-mars/blob/main/composer-local.json#L11).
