### PR TITLE
PLANET-7565: Upgrade to Wordpress 6.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -216,7 +216,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "6.6"
+    "wp-version": "6.6.1"
   },
 
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -216,7 +216,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "6.5.5"
+    "wp-version": "6.6"
   },
 
   "scripts": {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
This PR upgrades the DEV instance of WordPress to its LTS version ([6.6.1 of 23 July, 2024](https://wordpress.org/download/releases/))

<hr>

**RELATED PRs TO MERGE IN PARALLEL**
- https://github.com/greenpeace/planet4-develop/pull/44
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1222
- https://github.com/greenpeace/planet4-master-theme/pull/2330
- https://github.com/greenpeace/planet4-master-theme/pull/2345
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1230
- https://github.com/greenpeace/planet4-master-theme/pull/2337
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1226

<hr>

**NOTES:**

1. An interesting feature added with version 6.6 to be explored is the ability to customize content in synced patterns. This feature allows specific pieces of content to be customized in each instance of a synced pattern while keeping a consistent style for all instances. Currently, overrides can be set for Heading, Paragraph, Button, and Image blocks.

<hr>

**TESTING:**
Locally: Run `npx wp-env run cli wp core update --version=6.6` or `npx wp-env run cli wp core update https://wordpress.org/wordpress-6.6.zip` on your terminal