### PR TITLE
PLANET-7573: Upgrade ElasticPress to version 5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,7 +174,7 @@
     "wpackagist-plugin/akismet": "5.*",
     "wpackagist-plugin/cloudflare" : "4.*",
     "wpackagist-plugin/duplicate-post": "4.*",
-    "wpackagist-plugin/elasticpress":"4.7.*",
+    "wpackagist-plugin/elasticpress":"5.1.*",
     "wpackagist-plugin/google-apps-login": "3.4.6",
     "plugins/google-profile-avatars": "1.5",
     "plugins/gravityforms": "*",

--- a/development.json
+++ b/development.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "wpackagist-plugin/elasticpress":"4.7.*"
+    "wpackagist-plugin/elasticpress":"5.1.*"
   }
 }

--- a/development.json
+++ b/development.json
@@ -1,5 +1,0 @@
-{
-  "require": {
-    "wpackagist-plugin/elasticpress":"5.1.*"
-  }
-}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7573 

<hr>

**RELATED PR:**
https://github.com/greenpeace/planet4-master-theme/pull/2347

<hr>

**ERRORS FOUND:**
- The "Sync Elasticsearch" link in the "Search Content" page (`/wp-admin/admin.php?page=planet4_settings_search_content`) is incorrect. Should be updated or replaced.
- The "Sync Elasticsearch" link in the "Planet4 Control Panel" widget of the dashboard (`/wp-admin/index.php`) is incorrect. Should be updated or replaced.
- Clicking on "Check Elasticsearch" in the "Planet4 Control Panel" widget of the dashboard (`/wp-admin/index.php`) is not working and returns an error: `SyntaxError: JSON.parse: unexpected end of data at line 1 column 1 of the JSON data`
- The "WPML ElasticPress" plugin seems to crash the search results. This plugin was updated 9 months ago and never tested with WordPress 6.6.x. These are the search results in different scenarios using "ElasticPress", "WPML" (last version), and "WPML ElasticPress" (version 2.0.3):

> All plugins disabled: 28 results.
> **All plugins active: 0 results.**

> Only "ElasticPress" active: 16 results.
> Only "WPML" active: 25 results.
> Only "WPML ElasticPress" active: 28 results.

> "ElasticPress" and "WPML ElasticPress" active: 16 results.
> "ElasticPress" and "WPML" active: 16 results.
> "WPML" and "WPML ElasticPress" active: 25 results.

<hr>

**POSSIBLE CHANGES:**
- Version 5 includes the new Weighting Dashboard to manage the results weighting and the post type exclusions:
  - Maybe the Planet4 > Search content page (`/wp-admin/admin.php?page=planet4_settings_search_content`) becomes no longer necessary and could be removed.
  - The dashboard allows admin users to mark meta fields as indexable since meta keys are not indexed by default anymore. The new `ep_prepare_meta_allowed_keys` filter allows to add meta keys programmatically. Should we update our codebase?
- Features:
  - The `Users` feature was moved to the [ElasticPress Labs](https://github.com/10up/ElasticPressLabs) plugin (I think we are not using this feature, anyways).
  - The `Terms` and `Comments` features are available only if enabled via code (I think we are not using this feature, anyways).
  - Features now have their fields declared in JSON. Custom features may need to implement the `set_settings_schema()` method to work. See https://github.com/10up/ElasticPress/pull/3655.
    - Should we check our implementation in the `src/Search/ElasticSearch.php` file: 
      - Line 23: `\ElasticPress\Features::factory()->update_feature('facets', [ ... ]);`
      - Line 67: `return \ElasticPress\Features::factory()->get_registered_feature('facets')->is_active();` 

<hr>

**NOTES:**
- Version 5.0.0 does not require a full reindex but it is recommended, especially for websites using synonyms containing spaces. See [#3610](https://github.com/10up/ElasticPress/pull/3610).
- Our current plugin version is vulnerable to Cross-Site Request Forgery due to missing or incorrect nonce validation on the do_sync function. This makes it possible for unauthenticated attackers to sync data via a forged request granted they can trick a site administrator into performing an action such as clicking on a link. Further information [here](https://wpscan.com/vulnerability/52d874b2-4d02-4395-85b4-911a5e837e70/).
- All the "ElasticPress" hooks used in our codebase were reviewed (`ep_integrate`, `ep_post_match_fuzziness`, `ep_search_post_return_args`, `ep_valid_response`, `ep_setup_features`, `ep_indexable_post_types`). None of them is deprecated or affected by changes in newer plugin versions.
- All the [deprecated elements](https://github.com/10up/ElasticPress/releases?q=deprecated&expanded=true) from versions 3.5 to 5 were reviewed from the plugin changelog. None of them are affecting our code.
- I used the "Query Monitor" plugin to debug "ElasticPress". In every test, the number of queries found was one and no issue was detected.
- I tried to debug the plugin using "Debug Bar" and "ElasticPress Debugging Add-On" as suggested [here](https://www.elasticpress.io/documentation/article/using-the-elasticpress-debugging-add-on-plugin/). Still, it does not seem to work probably because [the latest plugin was not updated recently](https://wordpress.org/plugins/debug-bar-elasticpress/).