### PR TITLE
PLANET-7721 WPML upgraded to 4.6.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
       "type": "package",
       "package": {
         "name": "plugins/sitepress-multilingual-cms",
-        "version": "4.6.6",
+        "version": "4.6.15",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.6.6.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.6.15.zip",
           "type": "zip"
         }
       }
@@ -33,9 +33,9 @@
       "type": "package",
       "package": {
         "name": "plugins/wpml-elasticpress",
-        "version": "2.0.3",
+        "version": "2.0.4",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-elasticpress.2.0.3.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-elasticpress.2.0.4.zip",
           "type": "zip"
         }
       }
@@ -44,9 +44,9 @@
       "type": "package",
       "package": {
         "name": "plugins/wpml-string-translation",
-        "version": "3.2.3",
+        "version": "3.2.18",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-string-translation.3.2.3.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-string-translation.3.2.18.zip",
           "type": "zip"
         }
       }


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7721**

**Testing**

Updated composer file with new version of WPML

- To test this you can first upgrade your local env to the newer version using the command below
`npx wp-env run cli wp plugin install https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.6.15.zip --force`, this should update the version of the plugin installed. 
- After upgrading, everything should work as expected, no breaking changes.

Also, you can test the upgrades of the other plugins by running the following commands too.
`npx wp-env run cli wp plugin install https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-elasticpress.2.0.4.zip --force`

`npx wp-env run cli wp plugin install https://storage.googleapis.com/planet4-3rdparty-plugins/wpml-string-translation.3.2.18.zip --force`

Testing on multilingual sites has not raised any issues so far, even search seems to work as expected.