### PR TITLE
Deactivate blocks plugin on dev sites

### DIFF
--- a/tasks/post-deploy/10-deactivate-plugin.sh
+++ b/tasks/post-deploy/10-deactivate-plugin.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "$APP_ENV" = "development" ]; then
+  echo "Deactivate blocks plugin on dev sites..."
+  wp plugin deactivate planet4-plugin-gutenberg-blocks
+fi


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7740

### Testing

It's not easy to test this locally, but I used the [cidev instance](https://github.com/greenpeace/planet4-cidev/blob/fdd0aa261783246a0f9afc8e52fab29aa74d29f1/.circleci/config.yml#L30).

- On develop pipeline, you can see that the script [runs successfully](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/2738/workflows/2d3b8d89-bc1d-4341-ba92-b9ae3ca56a23/jobs/5723/parallel-runs/0/steps/0-107?invite=true#step-107-2892_43) (and verify it on the instance admin panel).