### PR TITLE
Add the Gravity Forms Survey add-on

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -168,6 +168,7 @@
     "plugins/gravityforms": "*",
     "plugins/gravityformshubspot": "*",
     "plugins/gravityformsquiz": "*",
+    "plugins/gravityformssurvey": "*",
     "wpackagist-plugin/post-type-switcher": "3.3.0",
     "wpackagist-plugin/redirection": "5.*",
     "wpackagist-plugin/wordpress-importer": "0.*",


### PR DESCRIPTION
### Summary

This PR adds the Gravity Forms Survey add-on as one of the required plugins of the base repository.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7827 