### PR TITLE
PLANET-7973: Upgrade ElasticPress to version 5.3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
     "wpackagist-plugin/akismet": "5.*",
     "wpackagist-plugin/cloudflare" : "4.*",
     "wpackagist-plugin/duplicate-post": "4.*",
-    "wpackagist-plugin/elasticpress":"5.2.*",
+    "wpackagist-plugin/elasticpress":"5.3.*",
     "wpackagist-plugin/google-apps-login": "3.4.6",
     "plugins/google-profile-avatars": "1.5",
     "plugins/gravityforms": "*",


### PR DESCRIPTION
### Summary

This PR updates the ElasticPress plugin to version 5.3.*

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7973

### Testing

Check the following elements, both locally and in the [test instance](https://www-dev.greenpeace.org/test-deimos):
- The [upstream Changelog](https://github.com/10up/ElasticPress/releases) for breaking or notable changes
- The new version in combination with WPML and WPML-Elasticpress plugins
- Search functionality still works as expected after the upgrade. Some scenarios that we could test:
  - Custom search results
  - Weighting options
  - Excluding posts from search
  - Listing pages in general