### PR TITLE
Upgrade Post Type Switcher plugin to version 4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,7 @@
     "plugins/gravityformshubspot": "*",
     "plugins/gravityformsquiz": "*",
     "plugins/gravityformssurvey": "*",
-    "wpackagist-plugin/post-type-switcher": "3.3.0",
+    "wpackagist-plugin/post-type-switcher": "4.*",
     "wpackagist-plugin/redirection": "5.*",
     "wpackagist-plugin/wordpress-importer": "0.*",
     "wpackagist-plugin/wp-redis": "1.4.*",


### PR DESCRIPTION
### Summary

This PR updates the Post Type Switcher plugin to version 4.0.* in order to mitigate the [vulnerability](https://wpscan.com/vulnerability/fb339dc7-e45d-4df2-b103-6a5f5458f368/) found on previous versions.

---

### Testing

- [Log in](https://www-dev.greenpeace.org/test-iocaste/wp-admin/) to the test instance.
- [Verify](https://www-dev.greenpeace.org/test-iocaste/wp-admin/plugins.php) that the plugin was upgraded to version 4.0.1
- Change the post type of various posts, pages, actions, and other elements, and verify that everything continues to function correctly.