### PR TITLE
PLANET-8061: Upgrade WordPress to v6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -205,7 +205,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "6.8.3"
+    "wp-version": "6.9"
   },
 
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
       "type": "package",
       "package": {
         "name": "plugins/sitepress-multilingual-cms",
-        "version": "4.6.15",
+        "version": "4.8.6",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.6.15.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.8.6.zip",
           "type": "zip"
         }
       }
@@ -55,9 +55,9 @@
       "type": "package",
       "package": {
         "name": "plugins/gravityforms",
-        "version": "2.9.23.2",
+        "version": "2.9.24",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/gravityforms_2.9.23.2.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/gravityforms_2.9.24.zip",
           "type": "zip"
         }
       }


### PR DESCRIPTION
### Summary

This PR upgrades WordPress to 6.9, and the following plugins to make them compatible with that version:
- WPML: https://wpml.org/changelog/2025/12/wpml-4-8-6-ready-for-wordpress-6-9s-breaking-change/
- GravityForms: https://docs.gravityforms.com/gravityforms-change-log/

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8061

---

### Related PRs

1. https://github.com/greenpeace/planet4-master-theme/pull/2827
2. https://github.com/greenpeace/planet4-develop/pull/62

---

### Testing

- Run your local instance.
- Upgrade the WordPress version: `npx wp-env run cli wp core update --version=6.9` 
- Upgrade the plugins:
  - WPML: `npx wp-env run cli wp plugin install https://storage.googleapis.com/planet4-3rdparty-plugins/sitepress-multilingual-cms.4.6.15.zip --force`
  - GravityForms: `npx wp-env run cli wp plugin install https://storage.googleapis.com/planet4-3rdparty-plugins/gravityforms_2.9.24.zip --force`