### PR TITLE
PLANET-8049: Create task to redirect to google login page

### DIFF
--- a/tasks/post-deploy/10-google-login-redirect.sh
+++ b/tasks/post-deploy/10-google-login-redirect.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Force to redirect to Google login page..."
+wp option patch update galogin ga_auto_login 1


### PR DESCRIPTION
# Summary
This script should run after the deploy.

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8049

## Testing
You can test it on local by:
- If you want to enable|disable the `Google Apps Login`, you might run `npx wp-env run cli wp plugin (activate|deactivate) google-apps-login`.
- If you want to force the Redirtection you might run `npx wp-env run cli wp option patch update galogin ga_auto_login (0|1)`.

