### PR TITLE
PLANET-8094 Upgraded Gravity Forms Hubspot Add-On

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,9 +77,9 @@
       "type": "package",
       "package": {
         "name": "plugins/gravityformshubspot",
-        "version": "2.3.2",
+        "version": "3.0.1",
         "dist": {
-          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/gravityformshubspot_2.3.2.zip",
+          "url": "https://storage.googleapis.com/planet4-3rdparty-plugins/gravityformshubspot_3.0.1.zip",
           "type": "zip"
         }
       }


### PR DESCRIPTION
### Summary
Upgrade the Add-On to fix issues reported in this [thread](https://greenpeace.slack.com/archives/C0151L0KKNX/p1768591537045569?thread_ts=1765444464.442069&cid=C0151L0KKNX)

### Related PR
https://github.com/greenpeace/planet4-master-theme/pull/2856

### Testing
Creating a form and integrating with HubSpot should work as expected for both new and existing forms