### PR TITLE
Remove psr/log library from requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -187,7 +187,6 @@
     "wpackagist-plugin/wp-sentry-integration":"8.*",
     "wpackagist-plugin/wp-stateless":"4.*",
     "wpackagist-plugin/wp-stateless-gravity-forms-addon":"0.0.3",
-    "psr/log": "1.*",
     "monolog/monolog": "^2.9",
     "timber/timber": "2.1.*"
   },


### PR DESCRIPTION
We don't need to have an explicit version here.
The library is being pulled as a dependency from other packages.

### Testing

It's mostly a logging library, so it shouldn't affect the application but mostly composer. I also couldn't find any usage of `\Psr\Log` namespace in our code.

1. On a fresh development environment change `planet4-bae` branch to this one by editing [.p4-env.json](https://github.com/greenpeace/planet4-develop/blob/main/.p4-env.json). Then run `env:install`. 
2. Installation should complete successfully. 
3. Keep an eye on the output for any errors relating to this change.