### PR TITLE
Upgrade WordPress to version 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
       "merge-extra-deep": false,
       "merge-scripts": true
     },
-    "wp-version": "6.9.4"
+    "wp-version": "7.0"
   },
 
   "scripts": {


### PR DESCRIPTION
### Description

See [PLANET-8182](https://greenpeace-planet4.atlassian.net/browse/PLANET-8182)

**Related PRs:** 
- https://github.com/greenpeace/planet4-develop/pull/67
- https://github.com/greenpeace/planet4-master-theme/pull/3018

### Testing

To check the new version on local, you can run `npx wp-env run cli wp core update`

[PLANET-8182]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ